### PR TITLE
Rename the session arguments to include the unit

### DIFF
--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -153,20 +153,20 @@ func cliConfig() *Config {
 	// Read the CLI config file content.
 	content, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		log.Printf("[ERROR] Error reading the CLI config file: %v", err)
+		log.Printf("[ERROR] Error reading the CLI config file %s: %v", configFilePath, err)
 		return config
 	}
 
 	// Parse the CLI config file content.
 	obj, err := hcl.Parse(string(content))
 	if err != nil {
-		log.Printf("[ERROR] Error parsing the CLI config file: %v", err)
+		log.Printf("[ERROR] Error parsing the CLI config file %s: %v", configFilePath, err)
 		return config
 	}
 
 	// Decode the CLI config file content.
 	if err := hcl.DecodeObject(&config, obj); err != nil {
-		log.Printf("[ERROR] Error decoding the CLI config file: %v", err)
+		log.Printf("[ERROR] Error decoding the CLI config file %s: %v", configFilePath, err)
 	}
 
 	return config

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -27,13 +27,13 @@ func resourceTFEOrganization() *schema.Resource {
 				Required: true,
 			},
 
-			"session_timeout": &schema.Schema{
+			"session_timeout_minutes": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  20160,
 			},
 
-			"session_remember": &schema.Schema{
+			"session_remember_minutes": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  20160,
@@ -95,8 +95,8 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	// Update the config.
 	d.Set("name", org.Name)
 	d.Set("email", org.Email)
-	d.Set("session_timeout", org.SessionTimeout)
-	d.Set("session_remember", org.SessionRemember)
+	d.Set("session_timeout_minutes", org.SessionTimeout)
+	d.Set("session_remember_minutes", org.SessionRemember)
 	d.Set("collaborator_auth_policy", string(org.CollaboratorAuthPolicy))
 
 	return nil
@@ -112,12 +112,12 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// If session_timeout is supplied, set it using the options struct.
-	if sessionTimeout, ok := d.GetOk("session_timeout"); ok {
+	if sessionTimeout, ok := d.GetOk("session_timeout_minutes"); ok {
 		options.SessionTimeout = tfe.Int(sessionTimeout.(int))
 	}
 
 	// If session_remember is supplied, set it using the options struct.
-	if sessionRemember, ok := d.GetOk("session_remember"); ok {
+	if sessionRemember, ok := d.GetOk("session_remember_minutes"); ok {
 		options.SessionRemember = tfe.Int(sessionRemember.(int))
 	}
 

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -28,9 +28,9 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout", "20160"),
+						"tfe_organization.foobar", "session_timeout_minutes", "20160"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember", "20160"),
+						"tfe_organization.foobar", "session_remember_minutes", "20160"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
@@ -58,9 +58,9 @@ func TestAccTFEOrganization_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout", "20160"),
+						"tfe_organization.foobar", "session_timeout_minutes", "20160"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember", "20160"),
+						"tfe_organization.foobar", "session_remember_minutes", "20160"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
@@ -77,9 +77,9 @@ func TestAccTFEOrganization_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin-updated@company.com"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout", "3600"),
+						"tfe_organization.foobar", "session_timeout_minutes", "3600"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember", "3600"),
+						"tfe_organization.foobar", "session_remember_minutes", "3600"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
@@ -129,11 +129,11 @@ func testAccCheckTFEOrganizationAttributes(
 		}
 
 		if org.SessionTimeout != 20160 {
-			return fmt.Errorf("Bad session timeout: %d", org.SessionTimeout)
+			return fmt.Errorf("Bad session timeout minutes: %d", org.SessionTimeout)
 		}
 
 		if org.SessionRemember != 20160 {
-			return fmt.Errorf("Bad session remember: %d", org.SessionRemember)
+			return fmt.Errorf("Bad session remember minutes: %d", org.SessionRemember)
 		}
 
 		if org.CollaboratorAuthPolicy != tfe.AuthPolicyPassword {
@@ -156,11 +156,11 @@ func testAccCheckTFEOrganizationAttributesUpdated(
 		}
 
 		if org.SessionTimeout != 3600 {
-			return fmt.Errorf("Bad session timeout: %d", org.SessionTimeout)
+			return fmt.Errorf("Bad session timeout minutes: %d", org.SessionTimeout)
 		}
 
 		if org.SessionRemember != 3600 {
-			return fmt.Errorf("Bad session remember: %d", org.SessionRemember)
+			return fmt.Errorf("Bad session remember minutes: %d", org.SessionRemember)
 		}
 
 		if org.CollaboratorAuthPolicy != tfe.AuthPolicyPassword {
@@ -202,6 +202,6 @@ const testAccTFEOrganization_update = `
 resource "tfe_organization" "foobar" {
   name = "terraform-updated"
   email = "admin-updated@company.com"
-  session_timeout = 3600
-  session_remember = 3600
+  session_timeout_minutes = 3600
+  session_remember_minutes = 3600
 }`

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -27,9 +27,9 @@ The following arguments are supported:
 
 * `name` - (Required) Name of the organization.
 * `email` - (Required) Admin email address.
-* `session_timeout` - (Optional) Session timeout after inactivity (minutes).
+* `session_timeout_minutes` - (Optional) Session timeout after inactivity.
   Defaults to `20160`.
-* `session_remember` - (Optional) Session expiration (minutes). Defaults to
+* `session_remember_minutes` - (Optional) Session expiration. Defaults to
   `20160`.
 * `collaborator_auth_policy` - (Optional) Authentication policy (`password`
   or `two_factor_mandatory`). Defaults to `password`.


### PR DESCRIPTION
Rename `session_timeout` to `session_timeout_minutes` and `session_remember` to `session_remember_minutes`.

Additionally we also added the config file path to all related error messages.

This addresses the additional comments on PR #3 from @paddycarver 