### PR TITLE
website: Explain how to authenticate when managing TFE w/ TFE

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -3,17 +3,43 @@ layout: "tfe"
 page_title: "Provider: Terraform Enterprise"
 sidebar_current: "docs-tfe-index"
 description: |-
-  The Terraform Enterprise provider is used to interact with the many resources supported by (Private) Terraform Enterprise. The provider needs to be configured with the proper credentials before it can be used.
+  The Terraform Enterprise provider is used to interact with the many resources supported by Terraform Enterprise. The provider needs to be configured with the proper credentials before it can be used.
 ---
 
 # Terraform Enterprise Provider
 
 The Terraform Enterprise provider is used to interact with the many resources
-supported by (Private) [Terraform Enterprise](https://www.hashicorp.com/products/terraform).
-The provider needs to be configured with the proper credentials before it can
-be used.
+supported by [Terraform Enterprise](https://www.hashicorp.com/products/terraform).
+It supports both the SaaS version of Terraform Enterprise
+([app.terraform.io](https://app.terraform.io)) and private instances.
 
 Use the navigation to the left to read about the available resources.
+
+## Authentication
+
+This provider requires a Terraform Enterprise API token in order to manage
+resources.
+
+To manage the full selection of resources, provide a
+[user token](/docs/enterprise/users-teams-organizations/users.html#api-tokens)
+from an account with appropriate permissions. This user should belong to the
+"owners" team of every Terraform Enterprise organization you wish to manage.
+
+-> **Note:** You can use [an organization or team token](/docs/enterprise/users-teams-organizations/service-accounts.html)
+instead of a user token, but it will limit which resources you can manage.
+Organization and team tokens cannot manage resources across multiple
+organizations, and organization tokens cannot manage certain resource types
+(like SSH keys or policies). See the
+[Terraform Enterprise API documentation](/docs/enterprise/api/index.html)
+for more details about access to resources.
+
+There are two ways to provide the required token:
+
+- On the CLI, omit the `token` argument and set a `credentials` block in your
+  [CLI config file](/docs/commands/cli-config.html#credentials).
+- In a Terraform Enterprise workspace, set `token` in the provider
+  configuration. Use an input variable for the token and mark the corresponding
+  variable in the workspace as sensitive.
 
 ## Example Usage
 
@@ -37,5 +63,7 @@ The following arguments are supported:
 * `hostname` - (Optional) The Terraform Enterprise hostname to connect to.
   Defaults to `app.terraform.io`.
 * `token` - (Optional) The token used to authenticate with Terraform Enterprise.
-	We recommend omitting the token which can be set as `credentials` in the
-  [CLI config file](/docs/commands/cli-config.html#credentials).
+  Only set this argument when running in a Terraform Enterprise workspace; for
+  CLI usage, omit the token from the configuration and set it as `credentials`
+  in the [CLI config file](/docs/commands/cli-config.html#credentials). See
+  [Authentication](#authentication) above for more.


### PR DESCRIPTION
TFE automatically writes a .terraformrc file with a credentials block when it
does Terraform runs, so theoretically the provider could authenticate
automatically. However, the automatically provided token is a temporary "run"
token with extremely limited privileges, and in practice it cannot manage any of
this provider's resources.

This PR also adjusts some confusing wording that implied the provider might not work with the SaaS.

(Screenshot, bc callout-within-a-list-item markdown is a lil squirrelly so I tested it to be sure:)

![screenshot_2018-08-27 provider terraform enterprise - terraform by hashicorp](https://user-images.githubusercontent.com/484309/44694246-4ac70600-aa21-11e8-8e80-15148cd693a6.png)
