### PR TITLE
Add `terraform import` support for some resources

### DIFF
--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -15,6 +15,9 @@ func resourceTFEOrganization() *schema.Resource {
 		Read:   resourceTFEOrganizationRead,
 		Update: resourceTFEOrganizationUpdate,
 		Delete: resourceTFEOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -33,13 +33,11 @@ func resourceTFEOrganization() *schema.Resource {
 			"session_timeout_minutes": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  20160,
 			},
 
 			"session_remember_minutes": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  20160,
 			},
 
 			"collaborator_auth_policy": &schema.Schema{

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -80,6 +80,25 @@ func TestAccTFEOrganization_update(t *testing.T) {
 	})
 }
 
+func TestAccTFEOrganization_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEOrganizationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEOrganization_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      "tfe_organization.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFEOrganizationExists(
 	n string, org *tfe.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -28,10 +28,6 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout_minutes", "20160"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember_minutes", "20160"),
-					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
 			},
@@ -57,10 +53,6 @@ func TestAccTFEOrganization_update(t *testing.T) {
 						"tfe_organization.foobar", "name", "terraform-test"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_timeout_minutes", "20160"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "session_remember_minutes", "20160"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 				),
@@ -126,14 +118,6 @@ func testAccCheckTFEOrganizationAttributes(
 
 		if org.Email != "admin@company.com" {
 			return fmt.Errorf("Bad email: %s", org.Email)
-		}
-
-		if org.SessionTimeout != 20160 {
-			return fmt.Errorf("Bad session timeout minutes: %d", org.SessionTimeout)
-		}
-
-		if org.SessionRemember != 20160 {
-			return fmt.Errorf("Bad session remember minutes: %d", org.SessionRemember)
 		}
 
 		if org.CollaboratorAuthPolicy != tfe.AuthPolicyPassword {

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -88,6 +88,10 @@ func resourceTFEOrganizationTokenRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error reading token from organization %s: %v", d.Id(), err)
 	}
 
+	// Update the organization using the ID. This is a bit
+	// unusual, but this enables importing the resource.
+	d.Set("organization", d.Id())
+
 	return nil
 }
 

--- a/tfe/resource_tfe_organization_token.go
+++ b/tfe/resource_tfe_organization_token.go
@@ -13,6 +13,9 @@ func resourceTFEOrganizationToken() *schema.Resource {
 		Create: resourceTFEOrganizationTokenCreate,
 		Read:   resourceTFEOrganizationTokenRead,
 		Delete: resourceTFEOrganizationTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"organization": &schema.Schema{

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -88,6 +88,26 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 	})
 }
 
+func TestAccTFEOrganizationToken_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEOrganizationTokenDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEOrganizationToken_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            "tfe_organization_token.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
+		},
+	})
+}
+
 func testAccCheckTFEOrganizationTokenExists(
 	n string, token *tfe.OrganizationToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -15,9 +15,6 @@ func resourceTFESentinelPolicy() *schema.Resource {
 		Read:   resourceTFESentinelPolicyRead,
 		Update: resourceTFESentinelPolicyUpdate,
 		Delete: resourceTFESentinelPolicyDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -15,6 +16,9 @@ func resourceTFESentinelPolicy() *schema.Resource {
 		Read:   resourceTFESentinelPolicyRead,
 		Update: resourceTFESentinelPolicyUpdate,
 		Delete: resourceTFESentinelPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceTFESentinelPolicyImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -165,4 +169,17 @@ func resourceTFESentinelPolicyDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	return nil
+}
+
+func resourceTFESentinelPolicyImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) != 2 {
+		return nil, fmt.Errorf("invalid Sentinel policy import format: %s", d.Id())
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("organization", s[0])
+	d.SetId(s[1])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -15,6 +15,9 @@ func resourceTFESentinelPolicy() *schema.Resource {
 		Read:   resourceTFESentinelPolicyRead,
 		Update: resourceTFESentinelPolicyUpdate,
 		Delete: resourceTFESentinelPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_sentinel_policy_test.go
+++ b/tfe/resource_tfe_sentinel_policy_test.go
@@ -76,6 +76,26 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 	})
 }
 
+func TestAccTFESentinelPolicy_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFESentinelPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFESentinelPolicy_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:        "tfe_sentinel_policy.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: "terraform-test/",
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFESentinelPolicyExists(
 	n string, policy *tfe.Policy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_ssh_key.go
+++ b/tfe/resource_tfe_ssh_key.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -14,6 +15,9 @@ func resourceTFESSHKey() *schema.Resource {
 		Read:   resourceTFESSHKeyRead,
 		Update: resourceTFESSHKeyUpdate,
 		Delete: resourceTFESSHKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceTFESSHKeyImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -112,4 +116,17 @@ func resourceTFESSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceTFESSHKeyImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) != 2 {
+		return nil, fmt.Errorf("invalid SSH key import format: %s", d.Id())
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("organization", s[0])
+	d.SetId(s[1])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_ssh_key.go
+++ b/tfe/resource_tfe_ssh_key.go
@@ -14,6 +14,9 @@ func resourceTFESSHKey() *schema.Resource {
 		Read:   resourceTFESSHKeyRead,
 		Update: resourceTFESSHKeyUpdate,
 		Delete: resourceTFESSHKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_ssh_key.go
+++ b/tfe/resource_tfe_ssh_key.go
@@ -14,9 +14,6 @@ func resourceTFESSHKey() *schema.Resource {
 		Read:   resourceTFESSHKeyRead,
 		Update: resourceTFESSHKeyUpdate,
 		Delete: resourceTFESSHKeyDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_ssh_key_test.go
+++ b/tfe/resource_tfe_ssh_key_test.go
@@ -70,6 +70,27 @@ func TestAccTFESSHKey_update(t *testing.T) {
 	})
 }
 
+func TestAccTFESSHKey_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFESSHKeyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFESSHKey_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            "tfe_ssh_key.foobar",
+				ImportState:             true,
+				ImportStateIdPrefix:     "terraform-test/",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
+		},
+	})
+}
+
 func testAccCheckTFESSHKeyExists(
 	n string, sshKey *tfe.SSHKey) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -13,6 +13,9 @@ func resourceTFETeam() *schema.Resource {
 		Create: resourceTFETeamCreate,
 		Read:   resourceTFETeamRead,
 		Delete: resourceTFETeamDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -13,6 +14,9 @@ func resourceTFETeam() *schema.Resource {
 		Create: resourceTFETeamCreate,
 		Read:   resourceTFETeamRead,
 		Delete: resourceTFETeamDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceTFETeamImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -87,4 +91,17 @@ func resourceTFETeamDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceTFETeamImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) != 2 {
+		return nil, fmt.Errorf("invalid team import format: %s", d.Id())
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("organization", s[0])
+	d.SetId(s[1])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -13,9 +13,6 @@ func resourceTFETeam() *schema.Resource {
 		Create: resourceTFETeamCreate,
 		Read:   resourceTFETeamRead,
 		Delete: resourceTFETeamDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -61,7 +58,7 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
 	log.Printf("[DEBUG] Read configuration of team: %s", d.Id())
-	_, err := tfeClient.Teams.Read(ctx, d.Id())
+	team, err := tfeClient.Teams.Read(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Team %s does no longer exist", d.Id())
@@ -70,6 +67,9 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		return fmt.Errorf("Error reading configuration of team %s: %v", d.Id(), err)
 	}
+
+	// Update the config.
+	d.Set("name", team.Name)
 
 	return nil
 }

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -14,6 +14,9 @@ func resourceTFETeamAccess() *schema.Resource {
 		Create: resourceTFETeamAccessCreate,
 		Read:   resourceTFETeamAccessRead,
 		Delete: resourceTFETeamAccessDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"access": &schema.Schema{
@@ -48,10 +51,15 @@ func resourceTFETeamAccess() *schema.Resource {
 func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get access, team ID, workspace and organization.
+	// Get access and team ID.
 	access := d.Get("access").(string)
 	teamID := d.Get("team_id").(string)
-	workspace, organization := unpackWorkspaceID(d.Get("workspace_id").(string))
+
+	// Get workspace and organization.
+	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error unpacking workspace ID: %v", err)
+	}
 
 	// Get the team.
 	tm, err := tfeClient.Teams.Read(ctx, teamID)

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -55,8 +55,8 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 	access := d.Get("access").(string)
 	teamID := d.Get("team_id").(string)
 
-	// Get workspace and organization.
-	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	// Get organization and workspace.
+	organization, workspace, err := unpackWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -15,7 +16,7 @@ func resourceTFETeamAccess() *schema.Resource {
 		Read:   resourceTFETeamAccessRead,
 		Delete: resourceTFETeamAccessDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceTFETeamAccessImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -132,4 +133,17 @@ func resourceTFETeamAccessDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	return nil
+}
+
+func resourceTFETeamAccessImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 3)
+	if len(s) != 3 {
+		return nil, fmt.Errorf("invalid team access import format: %s", d.Id())
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("workspace_id", s[0]+"/"+s[1])
+	d.SetId(s[2])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -31,6 +31,26 @@ func TestAccTFETeamAccess_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamAccess_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFETeamAccess_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:        "tfe_team_access.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: "terraform-test/workspace-test/",
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamAccessExists(
 	n string, tmAccess *tfe.TeamAccess) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_team_member.go
+++ b/tfe/resource_tfe_team_member.go
@@ -14,6 +14,9 @@ func resourceTFETeamMember() *schema.Resource {
 		Create: resourceTFETeamMemberCreate,
 		Read:   resourceTFETeamMemberRead,
 		Delete: resourceTFETeamMemberDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_id": &schema.Schema{

--- a/tfe/resource_tfe_team_member.go
+++ b/tfe/resource_tfe_team_member.go
@@ -60,8 +60,11 @@ func resourceTFETeamMemberCreate(d *schema.ResourceData, meta interface{}) error
 func resourceTFETeamMemberRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the team ID and username..
-	teamID, username := unpackTeamMemberID(d.Id())
+	// Get the team ID and username.
+	teamID, username, err := unpackTeamMemberID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error unpacking team member ID: %v", err)
+	}
 
 	log.Printf("[DEBUG] Read users from team: %s", teamID)
 	users, err := tfeClient.TeamMembers.List(ctx, teamID)
@@ -77,6 +80,8 @@ func resourceTFETeamMemberRead(d *schema.ResourceData, meta interface{}) error {
 	found := false
 	for _, user := range users {
 		if user.Username == username {
+			d.Set("team_id", teamID)
+			d.Set("username", username)
 			found = true
 			break
 		}
@@ -93,8 +98,11 @@ func resourceTFETeamMemberRead(d *schema.ResourceData, meta interface{}) error {
 func resourceTFETeamMemberDelete(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the team ID and username..
-	teamID, username := unpackTeamMemberID(d.Id())
+	// Get the team ID and username.
+	teamID, username, err := unpackTeamMemberID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error unpacking team member ID: %v", err)
+	}
 
 	// Create a new options struct.
 	options := tfe.TeamMemberRemoveOptions{
@@ -102,7 +110,7 @@ func resourceTFETeamMemberDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Remove user %q from team: %s", username, teamID)
-	err := tfeClient.TeamMembers.Remove(ctx, teamID, options)
+	err = tfeClient.TeamMembers.Remove(ctx, teamID, options)
 	if err != nil {
 		return fmt.Errorf("Error removing user %q to team %s: %v", username, teamID, err)
 	}
@@ -111,10 +119,19 @@ func resourceTFETeamMemberDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func packTeamMemberID(teamID, username string) string {
-	return teamID + "|" + username
+	return teamID + "/" + username
 }
 
-func unpackTeamMemberID(id string) (teamID, username string) {
-	s := strings.SplitN(id, "|", 2)
-	return s[0], s[1]
+func unpackTeamMemberID(id string) (teamID, username string, err error) {
+	// Support the old ID format for backwards compatibitily.
+	if s := strings.SplitN(id, "|", 2); len(s) == 2 {
+		return s[0], s[1], nil
+	}
+
+	s := strings.SplitN(id, "/", 2)
+	if len(s) != 2 {
+		return "", "", fmt.Errorf("invalid team member ID format: %s", id)
+	}
+
+	return s[0], s[1], nil
 }

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -31,6 +31,25 @@ func TestAccTFETeamMember_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamMember_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamMemberDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFETeamMember_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      "tfe_team_member.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamMemberExists(
 	n string, user *tfe.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -45,8 +45,11 @@ func testAccCheckTFETeamMemberExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the team ID and username..
-		teamID, username := unpackTeamMemberID(rs.Primary.ID)
+		// Get the team ID and username.
+		teamID, username, err := unpackTeamMemberID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error unpacking team member ID: %v", err)
+		}
 
 		users, err := tfeClient.TeamMembers.List(ctx, teamID)
 		if err != nil && err != tfe.ErrResourceNotFound {
@@ -92,8 +95,11 @@ func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the team ID and username..
-		teamID, username := unpackTeamMemberID(rs.Primary.ID)
+		// Get the team ID and username.
+		teamID, username, err := unpackTeamMemberID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error unpacking team member ID: %v", err)
+		}
 
 		users, err := tfeClient.TeamMembers.List(ctx, teamID)
 		if err != nil && err != tfe.ErrResourceNotFound {

--- a/tfe/resource_tfe_team_members.go
+++ b/tfe/resource_tfe_team_members.go
@@ -14,6 +14,9 @@ func resourceTFETeamMembers() *schema.Resource {
 		Read:   resourceTFETeamMembersRead,
 		Update: resourceTFETeamMembersUpdate,
 		Delete: resourceTFETeamMembersDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_id": &schema.Schema{

--- a/tfe/resource_tfe_team_members.go
+++ b/tfe/resource_tfe_team_members.go
@@ -37,7 +37,7 @@ func resourceTFETeamMembers() *schema.Resource {
 func resourceTFETeamMembersCreate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the team ID and username..
+	// Get the team ID.
 	teamID := d.Get("team_id").(string)
 
 	// Create a new options struct.
@@ -62,18 +62,15 @@ func resourceTFETeamMembersCreate(d *schema.ResourceData, meta interface{}) erro
 func resourceTFETeamMembersRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the team ID and username..
-	teamID := d.Get("team_id").(string)
-
-	log.Printf("[DEBUG] Read users from team: %s", teamID)
-	users, err := tfeClient.TeamMembers.List(ctx, teamID)
+	log.Printf("[DEBUG] Read users from team: %s", d.Id())
+	users, err := tfeClient.TeamMembers.List(ctx, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] Users do no longer exist")
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading users from team %s: %v", teamID, err)
+		return fmt.Errorf("Error reading users from team %s: %v", d.Id(), err)
 	}
 
 	var usernames []interface{}
@@ -82,6 +79,7 @@ func resourceTFETeamMembersRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if len(usernames) > 0 {
+		d.Set("team_id", d.Id())
 		d.Set("usernames", usernames)
 	} else {
 		log.Printf("[DEBUG] Users do no longer exist")
@@ -99,9 +97,6 @@ func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) erro
 		oldUsers := old.(*schema.Set).Difference(new.(*schema.Set))
 		newUsers := new.(*schema.Set).Difference(old.(*schema.Set))
 
-		// Get the team ID and username..
-		teamID := d.Get("team_id").(string)
-
 		// First add the new users.
 		if newUsers.Len() > 0 {
 			// Create a new options struct.
@@ -112,10 +107,10 @@ func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) erro
 				options.Usernames = append(options.Usernames, username.(string))
 			}
 
-			log.Printf("[DEBUG] Add users to team: %s", teamID)
-			err := tfeClient.TeamMembers.Add(ctx, teamID, options)
+			log.Printf("[DEBUG] Add users to team: %s", d.Id())
+			err := tfeClient.TeamMembers.Add(ctx, d.Id(), options)
 			if err != nil {
-				return fmt.Errorf("Error adding users to team %s: %v", teamID, err)
+				return fmt.Errorf("Error adding users to team %s: %v", d.Id(), err)
 			}
 		}
 
@@ -129,10 +124,10 @@ func resourceTFETeamMembersUpdate(d *schema.ResourceData, meta interface{}) erro
 				options.Usernames = append(options.Usernames, username.(string))
 			}
 
-			log.Printf("[DEBUG] Remove users from team: %s", teamID)
-			err := tfeClient.TeamMembers.Remove(ctx, teamID, options)
+			log.Printf("[DEBUG] Remove users from team: %s", d.Id())
+			err := tfeClient.TeamMembers.Remove(ctx, d.Id(), options)
 			if err != nil {
-				return fmt.Errorf("Error removing users to team %s: %v", teamID, err)
+				return fmt.Errorf("Error removing users to team %s: %v", d.Id(), err)
 			}
 		}
 	}

--- a/tfe/resource_tfe_team_members_test.go
+++ b/tfe/resource_tfe_team_members_test.go
@@ -75,6 +75,26 @@ func TestAccTFETeamMembers_update(t *testing.T) {
 		},
 	})
 }
+
+func TestAccTFETeamMembers_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamMembersDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFETeamMembers_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      "tfe_team_members.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamMembersExists(
 	n string, users *[]*tfe.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -31,6 +31,26 @@ func TestAccTFETeam_basic(t *testing.T) {
 	})
 }
 
+func TestAccTFETeam_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFETeam_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:        "tfe_team.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: "terraform-test/",
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamExists(
 	n string, team *tfe.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -13,6 +13,9 @@ func resourceTFETeamToken() *schema.Resource {
 		Create: resourceTFETeamTokenCreate,
 		Read:   resourceTFETeamTokenRead,
 		Delete: resourceTFETeamTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_id": &schema.Schema{

--- a/tfe/resource_tfe_team_token.go
+++ b/tfe/resource_tfe_team_token.go
@@ -89,6 +89,10 @@ func resourceTFETeamTokenRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error reading token from team %s: %v", d.Id(), err)
 	}
 
+	// Update the team ID using the ID. This is a bit
+	// unusual, but this enables importing the resource.
+	d.Set("team_id", d.Id())
+
 	return nil
 }
 

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -80,6 +80,26 @@ func TestAccTFETeamToken_existsWithForce(t *testing.T) {
 	})
 }
 
+func TestAccTFETeamToken_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamTokenDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFETeamToken_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            "tfe_team_token.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
+		},
+	})
+}
+
 func testAccCheckTFETeamTokenExists(
 	n string, token *tfe.TeamToken) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -15,6 +16,9 @@ func resourceTFEVariable() *schema.Resource {
 		Read:   resourceTFEVariableRead,
 		Update: resourceTFEVariableUpdate,
 		Delete: resourceTFEVariableDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceTFEVariableImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"key": &schema.Schema{
@@ -192,4 +196,17 @@ func resourceTFEVariableDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+func resourceTFEVariableImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 3)
+	if len(s) != 3 {
+		return nil, fmt.Errorf("invalid variable import format: %s", d.Id())
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("workspace_id", s[0]+"/"+s[1])
+	d.SetId(s[2])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -68,10 +68,15 @@ func resourceTFEVariable() *schema.Resource {
 func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get key, category, workspace and organization.
+	// Get key and category.
 	key := d.Get("key").(string)
 	category := d.Get("category").(string)
-	workspace, organization := unpackWorkspaceID(d.Get("workspace_id").(string))
+
+	// Get workspace and organization.
+	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error unpacking workspace ID: %v", err)
+	}
 
 	// Get the workspace.
 	ws, err := tfeClient.Workspaces.Read(ctx, organization, workspace)
@@ -105,7 +110,10 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
 	// Get workspace and organization.
-	workspace, organization := unpackWorkspaceID(d.Get("workspace_id").(string))
+	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error unpacking workspace ID: %v", err)
+	}
 
 	// Create a new options struct.
 	options := tfe.VariableListOptions{

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -72,8 +72,8 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 	key := d.Get("key").(string)
 	category := d.Get("category").(string)
 
-	// Get workspace and organization.
-	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	// Get organization and workspace.
+	organization, workspace, err := unpackWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -109,8 +109,8 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get workspace and organization.
-	workspace, organization, err := unpackWorkspaceID(d.Get("workspace_id").(string))
+	// Get organization and workspace.
+	organization, workspace, err := unpackWorkspaceID(d.Get("workspace_id").(string))
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -15,9 +15,6 @@ func resourceTFEVariable() *schema.Resource {
 		Read:   resourceTFEVariableRead,
 		Update: resourceTFEVariableUpdate,
 		Delete: resourceTFEVariableDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
 
 		Schema: map[string]*schema.Schema{
 			"key": &schema.Schema{
@@ -120,6 +117,8 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 		Organization: tfe.String(organization),
 		Workspace:    tfe.String(workspace),
 	}
+
+	// TODO (SvH): Use the (to be created) Read method instead!
 
 	log.Printf("[DEBUG] List variables of workspace: %s", workspace)
 	variables, err := tfeClient.Variables.List(ctx, options)

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -15,6 +15,9 @@ func resourceTFEVariable() *schema.Resource {
 		Read:   resourceTFEVariableRead,
 		Update: resourceTFEVariableUpdate,
 		Delete: resourceTFEVariableDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"key": &schema.Schema{

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -102,8 +102,8 @@ func testAccCheckTFEVariableExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the workspace and organization.
-		workspace, organization, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		// Get organization and workspace.
+		organization, workspace, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}
@@ -200,8 +200,8 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the workspace and organization.
-		workspace, organization, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		// Get organization and workspace.
+		organization, workspace, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -103,7 +103,10 @@ func testAccCheckTFEVariableExists(
 		}
 
 		// Get the workspace and organization.
-		workspace, organization := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		workspace, organization, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		if err != nil {
+			return fmt.Errorf("Error unpacking workspace ID: %v", err)
+		}
 
 		// Create a new options struct.
 		options := tfe.VariableListOptions{
@@ -198,7 +201,10 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 		}
 
 		// Get the workspace and organization.
-		workspace, organization := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		workspace, organization, err := unpackWorkspaceID(rs.Primary.Attributes["workspace_id"])
+		if err != nil {
+			return fmt.Errorf("Error unpacking workspace ID: %v", err)
+		}
 
 		// Create a new options struct.
 		options := tfe.VariableListOptions{

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -88,6 +88,26 @@ func TestAccTFEVariable_update(t *testing.T) {
 	})
 }
 
+func TestAccTFEVariable_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEVariableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEVariable_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:        "tfe_variable.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: "terraform-test/workspace-test/",
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFEVariableExists(
 	n string, variable *tfe.Variable) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -15,6 +15,9 @@ func resourceTFEWorkspace() *schema.Resource {
 		Read:   resourceTFEWorkspaceRead,
 		Update: resourceTFEWorkspaceUpdate,
 		Delete: resourceTFEWorkspaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -144,8 +144,8 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the name and organization.
-	name, organization, err := unpackWorkspaceID(d.Id())
+	// Get the organization and workspace name.
+	organization, name, err := unpackWorkspaceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -200,8 +200,8 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the name and organization.
-	name, organization, err := unpackWorkspaceID(d.Id())
+	// Get the organization and workspace name.
+	organization, name, err := unpackWorkspaceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -256,8 +256,8 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceTFEWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get the name and organization.
-	name, organization, err := unpackWorkspaceID(d.Id())
+	// Get the organization and workspace name.
+	organization, name, err := unpackWorkspaceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error unpacking workspace ID: %v", err)
 	}
@@ -279,13 +279,19 @@ func packWorkspaceID(w *tfe.Workspace) (id string, err error) {
 	if w.Organization == nil {
 		return "", fmt.Errorf("no organization in workspace response")
 	}
-	return w.Name + "|" + w.Organization.Name, nil
+	return w.Organization.Name + "/" + w.Name, nil
 }
 
-func unpackWorkspaceID(id string) (name, organization string, err error) {
-	s := strings.SplitN(id, "|", 2)
+func unpackWorkspaceID(id string) (organization, name string, err error) {
+	// Support the old ID format for backwards compatibitily.
+	if s := strings.SplitN(id, "|", 2); len(s) == 2 {
+		return s[1], s[0], nil
+	}
+
+	s := strings.SplitN(id, "/", 2)
 	if len(s) != 2 {
 		return "", "", fmt.Errorf("invalid workspace ID format: %s", id)
 	}
+
 	return s[0], s[1], nil
 }

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -93,14 +93,22 @@ func testAccCheckTFEWorkspaceExists(
 		}
 
 		// Get the name and organization.
-		name, organization := unpackWorkspaceID(rs.Primary.ID)
+		name, organization, err := unpackWorkspaceID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error unpacking workspace ID: %v", err)
+		}
 
 		w, err := tfeClient.Workspaces.Read(ctx, organization, name)
 		if err != nil {
 			return err
 		}
 
-		if packWorkspaceID(w) != rs.Primary.ID {
+		id, err := packWorkspaceID(workspace)
+		if err != nil {
+			return fmt.Errorf("Error creating ID for workspace %s: %v", name, err)
+		}
+
+		if id != rs.Primary.ID {
 			return fmt.Errorf("Workspace not found")
 		}
 
@@ -165,9 +173,12 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 		}
 
 		// Get the name and organization.
-		name, organization := unpackWorkspaceID(rs.Primary.ID)
+		name, organization, err := unpackWorkspaceID(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error unpacking workspace ID: %v", err)
+		}
 
-		_, err := tfeClient.Workspaces.Read(ctx, organization, name)
+		_, err = tfeClient.Workspaces.Read(ctx, organization, name)
 		if err == nil {
 			return fmt.Errorf("Workspace %s still exists", rs.Primary.ID)
 		}

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -78,6 +78,25 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 	})
 }
 
+func TestAccTFEWorkspace_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEWorkspace_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      "tfe_workspace.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckTFEWorkspaceExists(
 	n string, workspace *tfe.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -92,8 +92,8 @@ func testAccCheckTFEWorkspaceExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the name and organization.
-		name, organization, err := unpackWorkspaceID(rs.Primary.ID)
+		// Get the organization and workspace name.
+		organization, name, err := unpackWorkspaceID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}
@@ -103,7 +103,7 @@ func testAccCheckTFEWorkspaceExists(
 			return err
 		}
 
-		id, err := packWorkspaceID(workspace)
+		id, err := packWorkspaceID(w)
 		if err != nil {
 			return fmt.Errorf("Error creating ID for workspace %s: %v", name, err)
 		}
@@ -172,8 +172,8 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		// Get the name and organization.
-		name, organization, err := unpackWorkspaceID(rs.Primary.ID)
+		// Get the organization and workspace name.
+		organization, name, err := unpackWorkspaceID(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error unpacking workspace ID: %v", err)
 		}

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -15,7 +15,7 @@ Manages organizations.
 Basic usage:
 
 ```hcl
-resource "tfe_organization" "organization" {
+resource "tfe_organization" "test" {
   name = "my-org-name"
   email = "admin@company.com"
 }
@@ -37,3 +37,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The name of the organization.
+
+## Import
+
+Organizations can be imported using the `organization name`, e.g.
+
+```shell
+terraform import tfe_organization.test my-org-name
+```

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -16,7 +16,7 @@ can be used to act as the organization service account.
 Basic usage:
 
 ```hcl
-resource "tfe_organization_token" "token" {
+resource "tfe_organization_token" "test" {
   organization = "my-org-name"
 }
 ```
@@ -34,3 +34,11 @@ The following arguments are supported:
 
 * `id` - The ID of the token.
 * `token` - The generated token.
+
+## Import
+
+Organization tokens can be imported using the `organization name`, e.g.
+
+```shell
+terraform import tfe_organization_token.test my-org-name
+```

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -20,7 +20,7 @@ validated against the policy prior to the apply step.
 Basic usage:
 
 ```hcl
-resource "tfe_sentinel_policy" "policy" {
+resource "tfe_sentinel_policy" "test" {
   name = "my-policy-name"
   organization = "my-org-name"
   policy = "main = rule { true }"
@@ -42,3 +42,12 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The ID of the policy.
+
+## Import
+
+Sentinel policies can be imported by concatenating the `organization name` and
+`resource id`, e.g.
+
+```shell
+terraform import tfe_sentinel_policy.test my-org-name/pol-wAs3zYmWAhYK7peR
+```

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -16,7 +16,7 @@ key. An organization can have multiple SSH keys available.
 Basic usage:
 
 ```hcl
-resource "tfe_ssh_key" "ssh-key" {
+resource "tfe_ssh_key" "test" {
   name = "my-ssh-key-name"
   organization = "my-org-name"
   key = "private-ssh-key"
@@ -34,3 +34,12 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` The ID of the SSH key.
+
+## Import
+
+SSH keys can be imported by concatenating the `organization name` and
+`resource id`, e.g.
+
+```shell
+terraform import tfe_ssh_key.test my-org-name/sshkey-X3xvJx5VJbor5Tca
+```

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -15,7 +15,7 @@ Manages teams.
 Basic usage:
 
 ```hcl
-resource "tfe_team" "team" {
+resource "tfe_team" "test" {
   name = "my-team-name"
   organization = "my-org-name"
 }
@@ -31,3 +31,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` The ID of the team.
+
+## Import
+
+Teams can be imported by the `resource id`, e.g.
+
+```shell
+terraform import tfe_team.test team-47qC3LmA47piVan7
+```

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -15,20 +15,20 @@ Associate a team to permissions on a workspace.
 Basic usage:
 
 ```hcl
-resource "tfe_team" "team" {
+resource "tfe_team" "test" {
   name = "my-team-name"
   organization = "my-org-name"
 }
 
-resource "tfe_workspace" "workspace" {
+resource "tfe_workspace" "test" {
   name = "my-workspace-name"
   organization = "my-org-name"
 }
 
-resource "tfe_team_access" "access" {
+resource "tfe_team_access" "test" {
   access = "read"
-  team_id = "${tfe_team.team.id}"
-  workspace_id = "${tfe_workspace.workspace.id}"
+  team_id = "${tfe_team.test.id}"
+  workspace_id = "${tfe_workspace.test.id}"
 }
 ```
 
@@ -44,3 +44,12 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` The team access ID.
+
+## Import
+
+Team accesses can be imported by concatenating the `organization name`, the
+`workspace name` and the `resource id`, e.g.
+
+```shell
+terraform import tfe_team_access.test my-org-name/my-workspace-name/tws-8S5wnRbRpogw6apb
+```

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -22,13 +22,13 @@ used once. Both resources cannot be used for the same team simultaneously.
 Basic usage:
 
 ```hcl
-resource "tfe_team" "team" {
+resource "tfe_team" "test" {
   name = "my-team-name"
   organization = "my-org-name"
 }
 
-resource "tfe_team_member" "member" {
-  team_id = "${tfe_team.team.id}"
+resource "tfe_team_member" "test" {
+  team_id = "${tfe_team.test.id}"
   username = "sander"
 }
 ```
@@ -39,3 +39,12 @@ The following arguments are supported:
 
 * `team_id` - (Required) ID of the team.
 * `username` - (Required) Name of the user to add.
+
+## Import
+
+A team member can be imported by concatenating the `team id` and the
+`username`, e.g.
+
+```shell
+terraform import tfe_team_member.test team-47qC3LmA47piVan7/sander
+```

--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -22,13 +22,13 @@ used once. Both resources cannot be used for the same team simultaneously.
 Basic usage:
 
 ```hcl
-resource "tfe_team" "team" {
+resource "tfe_team" "test" {
   name = "my-team-name"
   organization = "my-org-name"
 }
 
-resource "tfe_team_members" "members" {
-  team_id = "${tfe_team.team.id}"
+resource "tfe_team_members" "test" {
+  team_id = "${tfe_team.test.id}"
   usernames = ["admin", "sander"]
 }
 ```
@@ -43,3 +43,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The ID of the team.
+
+## Import
+
+Team members can be imported by the `team id`, e.g.
+
+```shell
+terraform import tfe_team_members.test team-47qC3LmA47piVan7
+```

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -15,13 +15,13 @@ Generates a new team token and overrides existing token if one exists.
 Basic usage:
 
 ```hcl
-resource "tfe_team" "team" {
+resource "tfe_team" "test" {
   name = "my-team-name"
   organization = "my-org-name"
 }
 
-resource "tfe_team_token" "token" {
-  team_id = "${tfe_team.team.id}"
+resource "tfe_team_token" "test" {
+  team_id = "${tfe_team.test.id}"
 }
 ```
 
@@ -38,3 +38,11 @@ The following arguments are supported:
 
 * `id` - The ID of the token.
 * `token` - The generated token.
+
+## Import
+
+Team tokens can be imported by the `team id`, e.g.
+
+```shell
+terraform import tfe_team_token.test team-47qC3LmA47piVan7
+```

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -15,21 +15,21 @@ Creates, updates and destroys variables.
 Basic usage:
 
 ```hcl
-resource "tfe_organization" "organization" {
+resource "tfe_organization" "test" {
   name = "my-org-name"
   email = "admin@company.com"
 }
 
-resource "tfe_workspace" "workspace" {
+resource "tfe_workspace" "test" {
   name = "my-workspace-name"
-  organization = "${tfe_organization.organization.id}"
+  organization = "${tfe_organization.test.id}"
 }
 
-resource "tfe_variable" "variable" {
+resource "tfe_variable" "test" {
   key = "my_key_name"
   value = "my_value_name"
   category = "terraform"
-  workspace_id = "${tfe_workspace.workspace.id}"
+  workspace_id = "${tfe_workspace.test.id}"
 }
 ```
 
@@ -50,3 +50,12 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - The ID of the variable.
+
+## Import
+
+Variables can be imported by concatenating the `organization name`, the
+`workspace name` and the `resource id`, e.g.
+
+```shell
+terraform import tfe_variable.test my-org-name/my-workspace-name/var-5rTwnSaRPogw6apb
+```

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -15,9 +15,9 @@ Provides a workspace resource.
 Basic usage:
 
 ```hcl
-resource "tfe_workspace" "my-workspace" {
-  name = "my-workspace"
-  organization = "my-organization"
+resource "tfe_workspace" "test" {
+  name = "my-workspace-name"
+  organization = "my-org-name"
 }
 ```
 
@@ -46,3 +46,16 @@ The `vcs_repo` block supports:
   cloning the VCS repository. Defaults to `false`.
 * `oauth_token_id` - (Required) Token ID of the VCS Connection (OAuth Conection
   + Token) to use.
+
+## Attributes Reference
+
+* `id` - The ID of the workspace.
+
+## Import
+
+Workspaces can be imported by concatenating the `organization name` and the
+`workspace name`, e.g.
+
+```shell
+terraform import tfe_workspace.test my-org-name/my-workspace-name
+```


### PR DESCRIPTION
These are the main resources I’d like support for imports. This change adds very basic support. It’s not perfect and requires some `tfstate` file massaging. The main issue I’ve run into is that the Workspace state doesn’t get the organization id/name and forces a new resource, which is bad to do for Workspaces since it potentially breaks the Workspace.

I have not extensively tested the following providers but they seem to basically work: variable, team, team_members, team_member, sentinel_policy. Workspace and Organization are working with the above caveats.

Here’s an example import command:
`tf import tfe_workspace.terraform-repositories "terraform-repositories|hashicorp-v2”`