### PR TITLE
Tidy up docs and error messages for compound import IDs

### DIFF
--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -174,7 +174,10 @@ func resourceTFESentinelPolicyDelete(d *schema.ResourceData, meta interface{}) e
 func resourceTFESentinelPolicyImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
-		return nil, fmt.Errorf("invalid Sentinel policy import format: %s (expected <ORGANIZATION>/<RESOURCE ID>)", d.Id())
+		return nil, fmt.Errorf(
+		  "invalid Sentinel policy import format: %s (expected <ORGANIZATION>/<POLICY ID>)",
+		  d.Id()
+		)
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -174,7 +174,7 @@ func resourceTFESentinelPolicyDelete(d *schema.ResourceData, meta interface{}) e
 func resourceTFESentinelPolicyImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
-		return nil, fmt.Errorf("invalid Sentinel policy import format: %s", d.Id())
+		return nil, fmt.Errorf("invalid Sentinel policy import format: %s (expected <ORGANIZATION>/<RESOURCE ID>)", d.Id())
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -96,7 +96,10 @@ func resourceTFETeamDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceTFETeamImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
-		return nil, fmt.Errorf("invalid team import format: %s (expected <ORGANIZATION>/<RESOURCE ID>)", d.Id())
+		return nil, fmt.Errorf(
+		  "invalid team import format: %s (expected <ORGANIZATION>/<TEAM ID>)",
+		  d.Id()
+		)
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -96,7 +96,7 @@ func resourceTFETeamDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceTFETeamImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
-		return nil, fmt.Errorf("invalid team import format: %s", d.Id())
+		return nil, fmt.Errorf("invalid team import format: %s (expected <ORGANIZATION>/<RESOURCE ID>)", d.Id())
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -138,7 +138,10 @@ func resourceTFETeamAccessDelete(d *schema.ResourceData, meta interface{}) error
 func resourceTFETeamAccessImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 3)
 	if len(s) != 3 {
-		return nil, fmt.Errorf("invalid team access import format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>/<RESOURCE ID>)", d.Id())
+		return nil, fmt.Errorf(
+		  "invalid team access import format: %s (expected <ORGANIZATION>/<WORKSPACE>/<TEAM ACCESS ID>)",
+		  d.Id()
+		)
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -138,7 +138,7 @@ func resourceTFETeamAccessDelete(d *schema.ResourceData, meta interface{}) error
 func resourceTFETeamAccessImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 3)
 	if len(s) != 3 {
-		return nil, fmt.Errorf("invalid team access import format: %s", d.Id())
+		return nil, fmt.Errorf("invalid team access import format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>/<RESOURCE ID>)", d.Id())
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_team_member.go
+++ b/tfe/resource_tfe_team_member.go
@@ -135,7 +135,7 @@ func unpackTeamMemberID(id string) (teamID, username string, err error) {
 	s := strings.SplitN(id, "/", 2)
 	if len(s) != 2 {
 		return "", "", fmt.Errorf(
-			"invalid team member ID format (i.e. <organization>/<team>): %s", id)
+			"invalid team member ID format: %s (expected <TEAM ID>/<USERNAME>)", id)
 	}
 
 	return s[0], s[1], nil

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -173,7 +173,10 @@ func resourceTFEVariableDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceTFEVariableImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 3)
 	if len(s) != 3 {
-		return nil, fmt.Errorf("invalid variable import format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>/<RESOURCE ID>)", d.Id())
+		return nil, fmt.Errorf(
+		  "invalid variable import format: %s (expected <ORGANIZATION>/<WORKSPACE>/<VARIABLE ID>)",
+		  d.Id()
+		)
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -173,7 +173,7 @@ func resourceTFEVariableDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceTFEVariableImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.SplitN(d.Id(), "/", 3)
 	if len(s) != 3 {
-		return nil, fmt.Errorf("invalid variable import format: %s", d.Id())
+		return nil, fmt.Errorf("invalid variable import format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>/<RESOURCE ID>)", d.Id())
 	}
 
 	// Set the fields that are part of the import ID.

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -299,7 +299,7 @@ func unpackWorkspaceID(id string) (organization, name string, err error) {
 	s := strings.SplitN(id, "/", 2)
 	if len(s) != 2 {
 		return "", "", fmt.Errorf(
-			"invalid workspace ID format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>)", id)
+			"invalid workspace ID format: %s (expected <ORGANIZATION>/<WORKSPACE>)", id)
 	}
 
 	return s[0], s[1], nil

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -299,7 +299,7 @@ func unpackWorkspaceID(id string) (organization, name string, err error) {
 	s := strings.SplitN(id, "/", 2)
 	if len(s) != 2 {
 		return "", "", fmt.Errorf(
-			"invalid workspace ID format (i.e. <organization>/<workspace>): %s", id)
+			"invalid workspace ID format: %s (expected <ORGANIZATION>/<WORKSPACE NAME>)", id)
 	}
 
 	return s[0], s[1], nil

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -40,7 +40,8 @@ The following arguments are supported:
 
 ## Import
 
-Organizations can be imported with an ID of `<ORGANIZATION NAME>`. For example:
+Organizations can be imported; use `<ORGANIZATION NAME>` as the import ID. For
+example:
 
 ```shell
 terraform import tfe_organization.test my-org-name

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 ## Import
 
-Organizations can be imported using the `organization name`, e.g.
+Organizations can be imported with an ID of `<ORGANIZATION NAME>`. For example:
 
 ```shell
 terraform import tfe_organization.test my-org-name

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 ## Import
 
-Organization tokens can be imported using the `organization name`, e.g.
+Organization tokens can be imported with an ID of `<ORGANIZATION NAME>`. For example:
 
 ```shell
 terraform import tfe_organization_token.test my-org-name

--- a/website/docs/r/organization_token.html.markdown
+++ b/website/docs/r/organization_token.html.markdown
@@ -37,7 +37,8 @@ The following arguments are supported:
 
 ## Import
 
-Organization tokens can be imported with an ID of `<ORGANIZATION NAME>`. For example:
+Organization tokens can be imported; use `<ORGANIZATION NAME>` as the import ID.
+For example:
 
 ```shell
 terraform import tfe_organization_token.test my-org-name

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -45,8 +45,7 @@ The following arguments are supported:
 
 ## Import
 
-Sentinel policies can be imported by concatenating the `organization name` and
-`resource id`, e.g.
+Sentinel policies can be imported with an ID of `<ORGANIZATION NAME>/<RESOURCE ID>`. For example:
 
 ```shell
 terraform import tfe_sentinel_policy.test my-org-name/pol-wAs3zYmWAhYK7peR

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -45,7 +45,8 @@ The following arguments are supported:
 
 ## Import
 
-Sentinel policies can be imported with an ID of `<ORGANIZATION NAME>/<RESOURCE ID>`. For example:
+Sentinel policies can be imported; use `<ORGANIZATION NAME>/<POLICY ID>` as the
+import ID. For example:
 
 ```shell
 terraform import tfe_sentinel_policy.test my-org-name/pol-wAs3zYmWAhYK7peR

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -34,7 +34,8 @@ The following arguments are supported:
 
 ## Import
 
-Teams can be imported with an ID of `<ORGANIZATION NAME>/<RESOURCE ID>`. For example:
+Teams can be imported; use `<ORGANIZATION NAME>/<TEAM ID>` as the import ID. For
+example:
 
 ```shell
 terraform import tfe_team.test my-org-name/team-uomQZysH9ou42ZYY

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -34,9 +34,8 @@ The following arguments are supported:
 
 ## Import
 
-Teams can be imported by concatenating the `organization name` and the
-`team name`, e.g.
+Teams can be imported with an ID of `<ORGANIZATION NAME>/<RESOURCE ID>`. For example:
 
 ```shell
-terraform import tfe_team.test my-org-name/my-team-name
+terraform import tfe_team.test my-org-name/team-uomQZysH9ou42ZYY
 ```

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -47,8 +47,7 @@ The following arguments are supported:
 
 ## Import
 
-Team accesses can be imported by concatenating the `organization name`, the
-`workspace name` and the `resource id`, e.g.
+Team accesses can be imported with an ID of `<ORGANIZATION NAME>/<WORKSPACE NAME>/<RESOURCE ID>`. For example:
 
 ```shell
 terraform import tfe_team_access.test my-org-name/my-workspace-name/tws-8S5wnRbRpogw6apb

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -47,7 +47,9 @@ The following arguments are supported:
 
 ## Import
 
-Team accesses can be imported with an ID of `<ORGANIZATION NAME>/<WORKSPACE NAME>/<RESOURCE ID>`. For example:
+Team accesses can be imported; use
+`<ORGANIZATION NAME>/<WORKSPACE NAME>/<TEAM ACCESS ID>` as the import ID. For
+example:
 
 ```shell
 terraform import tfe_team_access.test my-org-name/my-workspace-name/tws-8S5wnRbRpogw6apb

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -42,7 +42,8 @@ The following arguments are supported:
 
 ## Import
 
-A team member can be imported with an ID of `<TEAM ID>/<USERNAME>`. For example:
+A team member can be imported; use `<TEAM ID>/<USERNAME>` as the import ID. For
+example:
 
 ```shell
 terraform import tfe_team_member.test team-47qC3LmA47piVan7/sander

--- a/website/docs/r/team_member.html.markdown
+++ b/website/docs/r/team_member.html.markdown
@@ -42,8 +42,7 @@ The following arguments are supported:
 
 ## Import
 
-A team member can be imported by concatenating the `team id` and the
-`username`, e.g.
+A team member can be imported with an ID of `<TEAM ID>/<USERNAME>`. For example:
 
 ```shell
 terraform import tfe_team_member.test team-47qC3LmA47piVan7/sander

--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 ## Import
 
-Team members can be imported with an ID of `<TEAM ID>`. For example:
+Team members can be imported; use `<TEAM ID>` as the import ID. For example:
 
 ```shell
 terraform import tfe_team_members.test team-47qC3LmA47piVan7

--- a/website/docs/r/team_members.html.markdown
+++ b/website/docs/r/team_members.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 ## Import
 
-Team members can be imported by the `team id`, e.g.
+Team members can be imported with an ID of `<TEAM ID>`. For example:
 
 ```shell
 terraform import tfe_team_members.test team-47qC3LmA47piVan7

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 ## Import
 
-Team tokens can be imported with an ID of `<TEAM ID>`. For example:
+Team tokens can be imported; use `<TEAM ID>` as the import ID. For example:
 
 ```shell
 terraform import tfe_team_token.test team-47qC3LmA47piVan7

--- a/website/docs/r/team_token.html.markdown
+++ b/website/docs/r/team_token.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 ## Import
 
-Team tokens can be imported by the `team id`, e.g.
+Team tokens can be imported with an ID of `<TEAM ID>`. For example:
 
 ```shell
 terraform import tfe_team_token.test team-47qC3LmA47piVan7

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -53,7 +53,9 @@ The following arguments are supported:
 
 ## Import
 
-Variables can be imported with an ID of `<ORGANIZATION NAME>/<WORKSPACE NAME>/<RESOURCE ID>`. For example:
+Variables can be imported; use
+`<ORGANIZATION NAME>/<WORKSPACE NAME>/<VARIABLE ID>` as the import ID. For
+example:
 
 ```shell
 terraform import tfe_variable.test my-org-name/my-workspace-name/var-5rTwnSaRPogw6apb

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -53,8 +53,7 @@ The following arguments are supported:
 
 ## Import
 
-Variables can be imported by concatenating the `organization name`, the
-`workspace name` and the `resource id`, e.g.
+Variables can be imported with an ID of `<ORGANIZATION NAME>/<WORKSPACE NAME>/<RESOURCE ID>`. For example:
 
 ```shell
 terraform import tfe_variable.test my-org-name/my-workspace-name/var-5rTwnSaRPogw6apb

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -56,8 +56,7 @@ The `vcs_repo` block supports:
 
 ## Import
 
-Workspaces can be imported by concatenating the `organization name` and the
-`workspace name`, e.g.
+Workspaces can be imported with an ID of `<ORGANIZATION NAME>/<WORKSPACE NAME>`. For example:
 
 ```shell
 terraform import tfe_workspace.test my-org-name/my-workspace-name

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -56,7 +56,8 @@ The `vcs_repo` block supports:
 
 ## Import
 
-Workspaces can be imported with an ID of `<ORGANIZATION NAME>/<WORKSPACE NAME>`. For example:
+Workspaces can be imported; use `<ORGANIZATION NAME>/<WORKSPACE NAME>` as the
+import ID. For example:
 
 ```shell
 terraform import tfe_workspace.test my-org-name/my-workspace-name


### PR DESCRIPTION
This PR updates the error messages to tell you what they were expecting. (I used the wrong ID format when I was testing Sentinel policies, and ended up going on a minor wild goose chase because I thought I had a different problem.)

Also, there was one inaccurate spot in the docs (`team`).