### PR TITLE
Add support for Sentinel policy sets

### DIFF
--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"tfe_organization":       resourceTFEOrganization(),
 			"tfe_organization_token": resourceTFEOrganizationToken(),
+			"tfe_policy_set":         resourceTFEPolicySet(),
 			"tfe_sentinel_policy":    resourceTFESentinelPolicy(),
 			"tfe_ssh_key":            resourceTFESSHKey(),
 			"tfe_team":               resourceTFETeam(),

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -1,0 +1,277 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceTFEPolicySet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEPolicySetCreate,
+		Read:   resourceTFEPolicySetRead,
+		Update: resourceTFEPolicySetUpdate,
+		Delete: resourceTFEPolicySetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"global": &schema.Schema{
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Default:       false,
+				ConflictsWith: []string{"workspace_external_ids"},
+			},
+
+			"organization": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"policy_ids": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"workspace_external_ids": &schema.Schema{
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"global"},
+			},
+		},
+	}
+}
+
+func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	name := d.Get("name").(string)
+	organization := d.Get("organization").(string)
+
+	// Create a new options struct.
+	options := tfe.PolicySetCreateOptions{
+		Name:   tfe.String(name),
+		Global: tfe.Bool(d.Get("global").(bool)),
+	}
+
+	if desc, ok := d.GetOk("description"); ok {
+		options.Description = tfe.String(desc.(string))
+	}
+
+	// Set up the policies and workspaces.
+	for _, policyID := range d.Get("policy_ids").(*schema.Set).List() {
+		options.Policies = append(options.Policies, &tfe.Policy{ID: policyID.(string)})
+	}
+
+	for _, workspaceID := range d.Get("workspace_external_ids").(*schema.Set).List() {
+		options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
+	}
+
+	log.Printf("[DEBUG] Create policy set %s for organization: %s", name, organization)
+	policySet, err := tfeClient.PolicySets.Create(ctx, organization, options)
+	if err != nil {
+		return fmt.Errorf(
+			"Error creating policy set %s for organization %s: %v", name, organization, err)
+	}
+
+	d.SetId(policySet.ID)
+
+	return resourceTFEPolicySetRead(d, meta)
+}
+
+func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Read policy set: %s", d.Id())
+	policySet, err := tfeClient.PolicySets.Read(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] Policy set %s does no longer exist", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading policy set %s: %v", d.Id(), err)
+	}
+
+	// Update the config.
+	d.Set("name", policySet.Name)
+	d.Set("description", policySet.Description)
+	d.Set("global", policySet.Global)
+
+	if policySet.Organization != nil {
+		d.Set("organization", policySet.Organization.Name)
+	}
+
+	// Update the relationships.
+	var policyIDs []interface{}
+	for _, policy := range policySet.Policies {
+		policyIDs = append(policyIDs, policy.ID)
+	}
+	d.Set("policy_ids", policyIDs)
+
+	if !policySet.Global {
+		var workspaceIDs []interface{}
+		for _, workspace := range policySet.Workspaces {
+			workspaceIDs = append(workspaceIDs, workspace.ID)
+		}
+		d.Set("workspace_external_ids", workspaceIDs)
+	}
+
+	return nil
+}
+
+func resourceTFEPolicySetUpdate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	name := d.Get("name").(string)
+	global := d.Get("global").(bool)
+
+	// If a user is setting the policy set to "global", make sure the workspaces
+	// that _had_ been set are explicitly removed. This helps keep the policy
+	// set's state in check
+	if d.HasChange("global") && global {
+		// The new set of workspaces will be an empty set, so we don't need it
+		oldSet, _ := d.GetChange("workspace_external_ids")
+		oldWorkspaceIDs := oldSet.(*schema.Set)
+
+		if oldWorkspaceIDs.Len() > 0 {
+			options := tfe.PolicySetDetachFromWorkspacesOptions{}
+
+			for _, workspaceID := range oldWorkspaceIDs.List() {
+				options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
+			}
+
+			log.Printf("[DEBUG] Removing previous workspaces from now-global policy set: %s", d.Id())
+			err := tfeClient.PolicySets.DetachFromWorkspaces(ctx, d.Id(), options)
+			if err != nil {
+				return fmt.Errorf("Error detaching policy set %s from workspaces: %v", d.Id(), err)
+			}
+		}
+	}
+
+	// Don't bother updating the policy set's attributes if they haven't changed
+	if d.HasChange("name") || d.HasChange("description") || d.HasChange("global") {
+		// Create a new options struct.
+		options := tfe.PolicySetUpdateOptions{
+			Name:   tfe.String(name),
+			Global: tfe.Bool(global),
+		}
+
+		if desc, ok := d.GetOk("description"); ok {
+			options.Description = tfe.String(desc.(string))
+		}
+
+		log.Printf("[DEBUG] Update configuration for policy set: %s", d.Id())
+		_, err := tfeClient.PolicySets.Update(ctx, d.Id(), options)
+		if err != nil {
+			return fmt.Errorf(
+				"Error updating configuration for policy set %s: %v", d.Id(), err)
+		}
+	}
+
+	if d.HasChange("policy_ids") {
+		oldSet, newSet := d.GetChange("policy_ids")
+		oldPolicyIDs := oldSet.(*schema.Set).Difference(newSet.(*schema.Set))
+		newPolicyIDs := newSet.(*schema.Set).Difference(oldSet.(*schema.Set))
+
+		// First add the new policies.
+		if newPolicyIDs.Len() > 0 {
+			options := tfe.PolicySetAddPoliciesOptions{}
+
+			for _, policyID := range newPolicyIDs.List() {
+				options.Policies = append(options.Policies, &tfe.Policy{ID: policyID.(string)})
+			}
+
+			log.Printf("[DEBUG] Add policies to policy set: %s", d.Id())
+			err := tfeClient.PolicySets.AddPolicies(ctx, d.Id(), options)
+			if err != nil {
+				return fmt.Errorf("Error adding policies to policy set %s: %v", d.Id(), err)
+			}
+		}
+
+		// Then remove all the old policies.
+		if oldPolicyIDs.Len() > 0 {
+			options := tfe.PolicySetRemovePoliciesOptions{}
+
+			for _, policyID := range oldPolicyIDs.List() {
+				options.Policies = append(options.Policies, &tfe.Policy{ID: policyID.(string)})
+			}
+
+			log.Printf("[DEBUG] Remove policies from policy set: %s", d.Id())
+			err := tfeClient.PolicySets.RemovePolicies(ctx, d.Id(), options)
+			if err != nil {
+				return fmt.Errorf("Error removing policies from policy set %s: %v", d.Id(), err)
+			}
+		}
+	}
+
+	if !global && d.HasChange("workspace_external_ids") {
+		oldSet, newSet := d.GetChange("workspace_external_ids")
+		oldWorkspaceIDs := oldSet.(*schema.Set).Difference(newSet.(*schema.Set))
+		newWorkspaceIDs := newSet.(*schema.Set).Difference(oldSet.(*schema.Set))
+
+		// First add the new policies.
+		if newWorkspaceIDs.Len() > 0 {
+			options := tfe.PolicySetAttachToWorkspacesOptions{}
+
+			for _, workspaceID := range newWorkspaceIDs.List() {
+				options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
+			}
+
+			log.Printf("[DEBUG] Attach policy set to workspaces: %s", d.Id())
+			err := tfeClient.PolicySets.AttachToWorkspaces(ctx, d.Id(), options)
+			if err != nil {
+				return fmt.Errorf("Error attaching policy set %s to workspaces: %v", d.Id(), err)
+			}
+		}
+
+		// Then remove all the old policies.
+		if oldWorkspaceIDs.Len() > 0 {
+			options := tfe.PolicySetDetachFromWorkspacesOptions{}
+
+			for _, workspaceID := range oldWorkspaceIDs.List() {
+				options.Workspaces = append(options.Workspaces, &tfe.Workspace{ID: workspaceID.(string)})
+			}
+
+			log.Printf("[DEBUG] Detach policy set from workspaces: %s", d.Id())
+			err := tfeClient.PolicySets.DetachFromWorkspaces(ctx, d.Id(), options)
+			if err != nil {
+				return fmt.Errorf("Error detaching policy set %s from workspaces: %v", d.Id(), err)
+			}
+		}
+	}
+
+	return resourceTFEPolicySetRead(d, meta)
+}
+
+func resourceTFEPolicySetDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Delete policy set: %s", d.Id())
+	err := tfeClient.PolicySets.Delete(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error deleting policy set %s: %v", d.Id(), err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -1,0 +1,577 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccTFEPolicySetCreate_basic(t *testing.T) {
+	policySet := &tfe.PolicySet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetAttributes(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "my-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set for some of my Sentinel policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "0"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetCreate_populated(t *testing.T) {
+	policySet := &tfe.PolicySet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_populated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetPopulated(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "populated-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetUpdate_basic(t *testing.T) {
+	policySet := &tfe.PolicySet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetAttributes(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "my-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set for some of my Sentinel policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "0"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "0"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccTFEPolicySet_populated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetPopulated(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "populated-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetUpdate_populated(t *testing.T) {
+	policySet := &tfe.PolicySet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_populated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetPopulated(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "populated-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "1"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccTFEPolicySet_newMembers,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetNewMembers(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "populated-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetUpdate_global(t *testing.T) {
+	policySet := &tfe.PolicySet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_populated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetPopulated(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "populated-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "1"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccTFEPolicySet_global,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetGlobal(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "global-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A global set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "true"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetUpdate_workspaceSwap(t *testing.T) {
+	policySet := &tfe.PolicySet{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_global,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetGlobal(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "global-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A global set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "true"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccTFEPolicySet_globalUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetExists("tfe_policy_set.my_set", policySet),
+					testAccCheckTFEPolicySetGlobalUpdate(policySet),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "name", "populated-set"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A set populated with some policies"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "false"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetImport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccTFEPolicySet_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      "tfe_policy_set.my_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTFEPolicySetExists(n string, policySet *tfe.PolicySet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		ps, err := tfeClient.PolicySets.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if ps.ID != rs.Primary.ID {
+			return fmt.Errorf("PolicySet not found")
+		}
+
+		*policySet = *ps
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetAttributes(policySet *tfe.PolicySet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if policySet.Name != "my-set" {
+			return fmt.Errorf("Bad name: %s", policySet.Name)
+		}
+
+		if policySet.Description != "A set for some of my Sentinel policies" {
+			return fmt.Errorf("Bad description: %s", policySet.Description)
+		}
+
+		if policySet.Global {
+			return fmt.Errorf("Bad value for global: %v", policySet.Global)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		if policySet.Name != "populated-set" {
+			return fmt.Errorf("Bad name: %s", policySet.Name)
+		}
+
+		if policySet.Description != "A set populated with some policies" {
+			return fmt.Errorf("Bad description: %s", policySet.Description)
+		}
+
+		if policySet.Global {
+			return fmt.Errorf("Bad value for global: %v", policySet.Global)
+		}
+
+		if len(policySet.Policies) != 1 {
+			return fmt.Errorf("Wrong number of policies: %v", len(policySet.Policies))
+		}
+
+		policyID := policySet.Policies[0].ID
+		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		if policy.Name != "policy-one" {
+			return fmt.Errorf("Wrong member policy: %v", policy.Name)
+		}
+
+		if len(policySet.Workspaces) != 1 {
+			return fmt.Errorf("Wrong number of workspaces: %v", len(policySet.Workspaces))
+		}
+
+		workspaceID := policySet.Workspaces[0].ID
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "terraform-test", "workspace-one")
+		if workspace.ID != workspaceID {
+			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetNewMembers(policySet *tfe.PolicySet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		if policySet.Name != "populated-set" {
+			return fmt.Errorf("Bad name: %s", policySet.Name)
+		}
+
+		if policySet.Description != "A set populated with some policies" {
+			return fmt.Errorf("Bad description: %s", policySet.Description)
+		}
+
+		if policySet.Global {
+			return fmt.Errorf("Bad value for global: %v", policySet.Global)
+		}
+
+		if len(policySet.Policies) != 1 {
+			return fmt.Errorf("Wrong number of policies: %v", len(policySet.Policies))
+		}
+
+		policyID := policySet.Policies[0].ID
+		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		if policy.Name != "policy-two" {
+			return fmt.Errorf("Wrong member policy: %v", policy.Name)
+		}
+
+		if len(policySet.Workspaces) != 1 {
+			return fmt.Errorf("Wrong number of workspaces: %v", len(policySet.Workspaces))
+		}
+
+		workspaceID := policySet.Workspaces[0].ID
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "terraform-test", "workspace-two")
+		if workspace.ID != workspaceID {
+			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		if policySet.Name != "global-set" {
+			return fmt.Errorf("Bad name: %s", policySet.Name)
+		}
+
+		if policySet.Description != "A global set populated with some policies" {
+			return fmt.Errorf("Bad description: %s", policySet.Description)
+		}
+
+		if !policySet.Global {
+			return fmt.Errorf("Bad value for global: %v", policySet.Global)
+		}
+
+		if len(policySet.Policies) != 1 {
+			return fmt.Errorf("Wrong number of policies: %v", len(policySet.Policies))
+		}
+
+		policyID := policySet.Policies[0].ID
+		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		if policy.Name != "policy-one" {
+			return fmt.Errorf("Wrong member policy: %v", policy.Name)
+		}
+
+		// Even though the terraform config should have 0 workspaces, the API will return
+		// workspaces for global policy sets. This list would be the same as listing the
+		// workspaces for the organization itself.
+		if len(policySet.Workspaces) != 1 {
+			return fmt.Errorf("Wrong number of workspaces: %v", len(policySet.Workspaces))
+		}
+
+		workspaceID := policySet.Workspaces[0].ID
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "terraform-test", "workspace-one")
+		if workspace.ID != workspaceID {
+			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetGlobalUpdate(policySet *tfe.PolicySet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		if policySet.Name != "populated-set" {
+			return fmt.Errorf("Bad name: %s", policySet.Name)
+		}
+
+		if policySet.Description != "A set populated with some policies" {
+			return fmt.Errorf("Bad description: %s", policySet.Description)
+		}
+
+		if policySet.Global {
+			return fmt.Errorf("Bad value for global: %v", policySet.Global)
+		}
+
+		if len(policySet.Policies) != 1 {
+			return fmt.Errorf("Wrong number of policies: %v", len(policySet.Policies))
+		}
+
+		policyID := policySet.Policies[0].ID
+		policy, _ := tfeClient.Policies.Read(ctx, policyID)
+		if policy.Name != "policy-one" {
+			return fmt.Errorf("Wrong member policy: %v", policy.Name)
+		}
+
+		if len(policySet.Workspaces) != 1 {
+			return fmt.Errorf("Wrong number of workspaces: %v", len(policySet.Workspaces))
+		}
+
+		workspaceID := policySet.Workspaces[0].ID
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "terraform-test", "workspace-two")
+		if workspace.ID != workspaceID {
+			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_policy_set" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.PolicySets.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Sentinel policy %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccTFEPolicySet_basic = `
+resource "tfe_organization" "foobar" {
+  name = "terraform-test"
+  email = "admin@company.com"
+}
+
+resource "tfe_policy_set" "my_set" {
+  name = "my-set"
+  description = "A set for some of my Sentinel policies"
+  organization = "${tfe_organization.foobar.id}"
+  policy_ids = []
+}`
+
+const testAccTFEPolicySet_populated = `
+resource "tfe_organization" "foobar" {
+  name = "terraform-test"
+  email = "admin@company.com"
+}
+
+resource "tfe_sentinel_policy" "one" {
+  name = "policy-one"
+  policy = "main = rule { true }"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "one" {
+  name = "workspace-one"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_policy_set" "my_set" {
+  name = "populated-set"
+  description = "A set populated with some policies"
+  organization = "${tfe_organization.foobar.id}"
+  policy_ids = ["${tfe_sentinel_policy.one.id}"]
+  workspace_external_ids = ["${tfe_workspace.one.external_id}"]
+}`
+
+const testAccTFEPolicySet_newMembers = `
+resource "tfe_organization" "foobar" {
+  name = "terraform-test"
+  email = "admin@company.com"
+}
+
+resource "tfe_sentinel_policy" "one" {
+  name = "policy-one"
+  policy = "main = rule { true }"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_sentinel_policy" "two" {
+  name = "policy-two"
+  policy = "main = rule { false }"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "two" {
+  name = "workspace-two"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_policy_set" "my_set" {
+  name = "populated-set"
+  description = "A set populated with some policies"
+  organization = "${tfe_organization.foobar.id}"
+  policy_ids = ["${tfe_sentinel_policy.two.id}"]
+  workspace_external_ids = ["${tfe_workspace.two.external_id}"]
+}`
+
+const testAccTFEPolicySet_global = `
+resource "tfe_organization" "foobar" {
+  name = "terraform-test"
+  email = "admin@company.com"
+}
+
+resource "tfe_sentinel_policy" "one" {
+  name = "policy-one"
+  policy = "main = rule { true }"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "one" {
+  name = "workspace-one"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_policy_set" "my_set" {
+  name = "global-set"
+  description = "A global set populated with some policies"
+  organization = "${tfe_organization.foobar.id}"
+  global = true
+  policy_ids = ["${tfe_sentinel_policy.one.id}"]
+}`
+
+const testAccTFEPolicySet_globalUpdate = `
+resource "tfe_organization" "foobar" {
+  name = "terraform-test"
+  email = "admin@company.com"
+}
+
+resource "tfe_sentinel_policy" "one" {
+  name = "policy-one"
+  policy = "main = rule { true }"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "one" {
+  name = "workspace-one"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "two" {
+  name = "workspace-two"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_policy_set" "my_set" {
+  name = "populated-set"
+  description = "A set populated with some policies"
+  organization = "${tfe_organization.foobar.id}"
+  policy_ids = ["${tfe_sentinel_policy.one.id}"]
+  workspace_external_ids = ["${tfe_workspace.two.external_id}"]
+}`

--- a/tfe/resource_tfe_sentinel_policy_test.go
+++ b/tfe/resource_tfe_sentinel_policy_test.go
@@ -26,6 +26,8 @@ func TestAccTFESentinelPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "name", "policy-test"),
 					resource.TestCheckResourceAttr(
+						"tfe_sentinel_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "policy", "main = rule { true }"),
 					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "enforce_mode", "hard-mandatory"),
@@ -52,6 +54,8 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "name", "policy-test"),
 					resource.TestCheckResourceAttr(
+						"tfe_sentinel_policy.foobar", "description", "A test policy"),
+					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "policy", "main = rule { true }"),
 					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "enforce_mode", "hard-mandatory"),
@@ -66,6 +70,8 @@ func TestAccTFESentinelPolicy_update(t *testing.T) {
 					testAccCheckTFESentinelPolicyAttributesUpdated(policy),
 					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "name", "policy-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_sentinel_policy.foobar", "description", "An updated test policy"),
 					resource.TestCheckResourceAttr(
 						"tfe_sentinel_policy.foobar", "policy", "main = rule { false }"),
 					resource.TestCheckResourceAttr(
@@ -184,6 +190,7 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_sentinel_policy" "foobar" {
   name = "policy-test"
+  description = "A test policy"
   organization = "${tfe_organization.foobar.id}"
   policy = "main = rule { true }"
   enforce_mode = "hard-mandatory"
@@ -197,6 +204,7 @@ resource "tfe_organization" "foobar" {
 
 resource "tfe_sentinel_policy" "foobar" {
   name = "policy-test"
+  description = "An updated test policy"
   organization = "${tfe_organization.foobar.id}"
   policy = "main = rule { false }"
   enforce_mode = "soft-mandatory"

--- a/vendor/github.com/hashicorp/go-tfe/README.md
+++ b/vendor/github.com/hashicorp/go-tfe/README.md
@@ -28,6 +28,7 @@ Currently the following endpoints are supported:
 - [x] [Organizations](https://www.terraform.io/docs/enterprise/api/organizations.html)
 - [x] [Organization Tokens](https://www.terraform.io/docs/enterprise/api/organization-tokens.html)
 - [x] [Policies](https://www.terraform.io/docs/enterprise/api/policies.html)
+- [x] [Policy Sets](https://www.terraform.io/docs/enterprise/api/policy-sets.html)
 - [x] [Policy Checks](https://www.terraform.io/docs/enterprise/api/policy-checks.html)
 - [ ] [Registry Modules](https://www.terraform.io/docs/enterprise/api/modules.html)
 - [x] [Runs](https://www.terraform.io/docs/enterprise/api/run.html)

--- a/vendor/github.com/hashicorp/go-tfe/apply.go
+++ b/vendor/github.com/hashicorp/go-tfe/apply.go
@@ -34,14 +34,15 @@ type ApplyStatus string
 
 //List all available apply statuses.
 const (
-	ApplyCanceled   ApplyStatus = "canceled"
-	ApplyCreated    ApplyStatus = "created"
-	ApplyErrored    ApplyStatus = "errored"
-	ApplyFinished   ApplyStatus = "finished"
-	ApplyMFAWaiting ApplyStatus = "mfa_waiting"
-	ApplyPending    ApplyStatus = "pending"
-	ApplyQueued     ApplyStatus = "queued"
-	ApplyRunning    ApplyStatus = "running"
+	ApplyCanceled    ApplyStatus = "canceled"
+	ApplyCreated     ApplyStatus = "created"
+	ApplyErrored     ApplyStatus = "errored"
+	ApplyFinished    ApplyStatus = "finished"
+	ApplyMFAWaiting  ApplyStatus = "mfa_waiting"
+	ApplyPending     ApplyStatus = "pending"
+	ApplyQueued      ApplyStatus = "queued"
+	ApplyRunning     ApplyStatus = "running"
+	ApplyUnreachable ApplyStatus = "unreachable"
 )
 
 // Apply represents a Terraform Enterprise apply.
@@ -115,7 +116,7 @@ func (s *applies) Logs(ctx context.Context, applyID string) (io.Reader, error) {
 		}
 
 		switch a.Status {
-		case ApplyCanceled, ApplyErrored, ApplyFinished:
+		case ApplyCanceled, ApplyErrored, ApplyFinished, ApplyUnreachable:
 			return true, nil
 		default:
 			return false, nil

--- a/vendor/github.com/hashicorp/go-tfe/logreader.go
+++ b/vendor/github.com/hashicorp/go-tfe/logreader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -11,11 +12,24 @@ import (
 
 // LogReader implements io.Reader for streaming logs.
 type LogReader struct {
-	client *Client
-	ctx    context.Context
-	done   func() (bool, error)
-	logURL *url.URL
-	offset int64
+	client      *Client
+	ctx         context.Context
+	done        func() (bool, error)
+	logURL      *url.URL
+	offset      int64
+	reads       int
+	startOfText bool
+	endOfText   bool
+}
+
+// backoff will perform exponential backoff based on the iteration and
+// limited by the provided min and max (in milliseconds) durations.
+func backoff(min, max float64, iter int) time.Duration {
+	backoff := math.Pow(2, float64(iter)/5) * min
+	if backoff > max {
+		backoff = max
+	}
+	return time.Duration(backoff) * time.Millisecond
 }
 
 func (r *LogReader) Read(l []byte) (int, error) {
@@ -26,11 +40,11 @@ func (r *LogReader) Read(l []byte) (int, error) {
 	// Loop until we can any data, the context is canceled or the
 	// run is finsished. If we would return right away without any
 	// data, we could and up causing a io.ErrNoProgress error.
-	for {
+	for r.reads = 1; ; r.reads++ {
 		select {
 		case <-r.ctx.Done():
 			return 0, r.ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(backoff(500, 2000, r.reads)):
 			if written, err := r.read(l); err != io.ErrNoProgress {
 				return written, err
 			}
@@ -70,16 +84,49 @@ func (r *LogReader) read(l []byte) (int, error) {
 		return written, err
 	}
 
+	if written > 0 {
+		// Check for an STX (Start of Text) ASCII control marker.
+		if !r.startOfText && l[0] == byte(2) {
+			r.startOfText = true
+
+			// Remove the STX marker from the received chunk.
+			copy(l[:written-1], l[1:])
+			l[written-1] = byte(0)
+			r.offset++
+			written--
+
+			// Return early if we only received the STX marker.
+			if written == 0 {
+				return 0, io.ErrNoProgress
+			}
+		}
+
+		// If we found an STX ASCII control character, start looking for
+		// the ETX (End of Text) control character.
+		if r.startOfText && l[written-1] == byte(3) {
+			r.endOfText = true
+
+			// Remove the ETX marker from the received chunk.
+			l[written-1] = byte(0)
+			r.offset++
+			written--
+		}
+	}
+
 	// Check if we need to continue the loop and wait 500 miliseconds
 	// before checking if there is a new chunk available or that the
 	// run is finished and we are done reading all chunks.
 	if written == 0 {
-		done, err := r.done()
-		if err != nil {
-			return 0, err
-		}
-		if done {
-			return 0, io.EOF
+		if (r.startOfText && r.endOfText) || // The logstream finished without issues.
+			(r.startOfText && r.reads%10 == 0) || // The logstream terminated unexpectedly.
+			(!r.startOfText && r.reads > 1) { // The logstream doesn't support STX/ETX.
+			done, err := r.done()
+			if err != nil {
+				return 0, err
+			}
+			if done {
+				return 0, io.EOF
+			}
 		}
 		return 0, io.ErrNoProgress
 	}

--- a/vendor/github.com/hashicorp/go-tfe/organization.go
+++ b/vendor/github.com/hashicorp/go-tfe/organization.go
@@ -31,6 +31,12 @@ type Organizations interface {
 
 	// Delete an organization by its name.
 	Delete(ctx context.Context, organization string) error
+
+	// Capacity shows the current run capacity of an organization.
+	Capacity(ctx context.Context, organization string) (*Capacity, error)
+
+	// RunQueue shows the current run queue of an organization.
+	RunQueue(ctx context.Context, organization string, options RunQueueOptions) (*RunQueue, error)
 }
 
 // organizations implements Organizations.
@@ -78,6 +84,19 @@ type Organization struct {
 	SessionTimeout         int                      `jsonapi:"attr,session-timeout"`
 	TrialExpiresAt         time.Time                `jsonapi:"attr,trial-expires-at,iso8601"`
 	TwoFactorConformant    bool                     `jsonapi:"attr,two-factor-conformant"`
+}
+
+// Capacity represents the current run capacity of an organization.
+type Capacity struct {
+	Organization string `jsonapi:"primary,organization-capacity"`
+	Pending      int    `jsonapi:"attr,pending"`
+	Running      int    `jsonapi:"attr,running"`
+}
+
+// RunQueue represents the current run queue of an organization.
+type RunQueue struct {
+	*Pagination
+	Items []*Run
 }
 
 // OrganizationPermissions represents the organization permissions.
@@ -241,4 +260,51 @@ func (s *organizations) Delete(ctx context.Context, organization string) error {
 	}
 
 	return s.client.do(ctx, req, nil)
+}
+
+// Capacity shows the currently used capacity of an organization.
+func (s *organizations) Capacity(ctx context.Context, organization string) (*Capacity, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("Invalid value for organization")
+	}
+
+	u := fmt.Sprintf("organizations/%s/capacity", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Capacity{}
+	err = s.client.do(ctx, req, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// RunQueueOptions represents the options for showing the queue.
+type RunQueueOptions struct {
+	ListOptions
+}
+
+// RunQueue shows the current run queue of an organization.
+func (s *organizations) RunQueue(ctx context.Context, organization string, options RunQueueOptions) (*RunQueue, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("Invalid value for organization")
+	}
+
+	u := fmt.Sprintf("organizations/%s/runs/queue", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rq := &RunQueue{}
+	err = s.client.do(ctx, req, rq)
+	if err != nil {
+		return nil, err
+	}
+
+	return rq, nil
 }

--- a/vendor/github.com/hashicorp/go-tfe/plan.go
+++ b/vendor/github.com/hashicorp/go-tfe/plan.go
@@ -34,14 +34,15 @@ type PlanStatus string
 
 //List all available plan statuses.
 const (
-	PlanCanceled   PlanStatus = "canceled"
-	PlanCreated    PlanStatus = "created"
-	PlanErrored    PlanStatus = "errored"
-	PlanFinished   PlanStatus = "finished"
-	PlanMFAWaiting PlanStatus = "mfa_waiting"
-	PlanPending    PlanStatus = "pending"
-	PlanQueued     PlanStatus = "queued"
-	PlanRunning    PlanStatus = "running"
+	PlanCanceled    PlanStatus = "canceled"
+	PlanCreated     PlanStatus = "created"
+	PlanErrored     PlanStatus = "errored"
+	PlanFinished    PlanStatus = "finished"
+	PlanMFAWaiting  PlanStatus = "mfa_waiting"
+	PlanPending     PlanStatus = "pending"
+	PlanQueued      PlanStatus = "queued"
+	PlanRunning     PlanStatus = "running"
+	PlanUnreachable PlanStatus = "unreachable"
 )
 
 // Plan represents a Terraform Enterprise plan.
@@ -116,7 +117,7 @@ func (s *plans) Logs(ctx context.Context, planID string) (io.Reader, error) {
 		}
 
 		switch p.Status {
-		case PlanCanceled, PlanErrored, PlanFinished:
+		case PlanCanceled, PlanErrored, PlanFinished, PlanUnreachable:
 			return true, nil
 		default:
 			return false, nil

--- a/vendor/github.com/hashicorp/go-tfe/policy_check.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_check.go
@@ -51,13 +51,14 @@ type PolicyStatus string
 
 //List all available policy check statuses.
 const (
-	PolicyErrored    PolicyStatus = "errored"
-	PolicyHardFailed PolicyStatus = "hard_failed"
-	PolicyOverridden PolicyStatus = "overridden"
-	PolicyPasses     PolicyStatus = "passed"
-	PolicyPending    PolicyStatus = "pending"
-	PolicyQueued     PolicyStatus = "queued"
-	PolicySoftFailed PolicyStatus = "soft_failed"
+	PolicyErrored     PolicyStatus = "errored"
+	PolicyHardFailed  PolicyStatus = "hard_failed"
+	PolicyOverridden  PolicyStatus = "overridden"
+	PolicyPasses      PolicyStatus = "passed"
+	PolicyPending     PolicyStatus = "pending"
+	PolicyQueued      PolicyStatus = "queued"
+	PolicySoftFailed  PolicyStatus = "soft_failed"
+	PolicyUnreachable PolicyStatus = "unreachable"
 )
 
 // PolicyCheckList represents a list of policy checks.

--- a/vendor/github.com/hashicorp/go-tfe/policy_set.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_set.go
@@ -1,0 +1,381 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ PolicySets = (*policySets)(nil)
+
+// PolicySets describes all the policy set related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/enterprise/api/policies.html
+type PolicySets interface {
+	// List all the policy sets for a given organization
+	List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error)
+
+	// Create a policy set and associate it with an organization.
+	Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error)
+
+	// Read a policy set by its ID.
+	Read(ctx context.Context, policySetID string) (*PolicySet, error)
+
+	// Update an existing policy set.
+	Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error)
+
+	// Add policies to a policy set.
+	AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error
+
+	// Remove policies from a policy set.
+	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
+
+	// Attach a policy set to workspaces.
+	AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error
+
+	// Detach a policy set from workspaces.
+	DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error
+
+	// Delete a policy set by its ID.
+	Delete(ctx context.Context, policyID string) error
+}
+
+// policySets implements PolicySets.
+type policySets struct {
+	client *Client
+}
+
+// PolicySetList represents a list of policy sets..
+type PolicySetList struct {
+	*Pagination
+	Items []*PolicySet
+}
+
+// PolicySet represents a Terraform Enterprise policy set.
+type PolicySet struct {
+	ID             string    `jsonapi:"primary,policy-sets"`
+	Name           string    `jsonapi:"attr,name"`
+	Description    string    `jsonapi:"attr,description"`
+	Global         bool      `jsonapi:"attr,global"`
+	PolicyCount    int       `jsonapi:"attr,policy-count"`
+	WorkspaceCount int       `jsonapi:"attr,workspace-count"`
+	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt      time.Time `jsonapi:"attr,updated-at,iso8601"`
+
+	// Relations
+	Organization *Organization `jsonapi:"relation,organization"`
+	Policies     []*Policy     `jsonapi:"relation,policies"`
+	Workspaces   []*Workspace  `jsonapi:"relation,workspaces"`
+}
+
+// PolicySetListOptions represents the options for listing policy sets.
+type PolicySetListOptions struct {
+	ListOptions
+
+	// A search string (partial policy set name) used to filter the results.
+	Search *string `url:"search[name],omitempty"`
+}
+
+// List all the policies for a given organization
+func (s *policySets) List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("Invalid value for organization")
+	}
+
+	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	psl := &PolicySetList{}
+	err = s.client.do(ctx, req, psl)
+	if err != nil {
+		return nil, err
+	}
+
+	return psl, nil
+}
+
+// PolicySetCreateOptions represents the options for creating a new policy set.
+type PolicySetCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,policy-sets"`
+
+	// The name of the policy set.
+	Name *string `jsonapi:"attr,name"`
+
+	// The description of the policy set.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
+	// Whether or not the policy set is global.
+	Global *bool `jsonapi:"attr,global,omitempty"`
+
+	// The initial members of the policy set.
+	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
+
+	// The initial list of workspaces the policy set should be attached to.
+	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`
+}
+
+func (o PolicySetCreateOptions) valid() error {
+	if !validString(o.Name) {
+		return errors.New("Name is required")
+	}
+	if !validStringID(o.Name) {
+		return errors.New("Invalid value for name")
+	}
+	return nil
+}
+
+// Create a policy set and associate it with an organization.
+func (s *policySets) Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("Invalid value for organization")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &PolicySet{}
+	err = s.client.do(ctx, req, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, err
+}
+
+// Read a policy set by its ID.
+func (s *policySets) Read(ctx context.Context, policySetID string) (*PolicySet, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("Invalid value for policy set ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &PolicySet{}
+	err = s.client.do(ctx, req, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, err
+}
+
+// PolicySetUpdateOptions represents the options for updating a policy set.
+type PolicySetUpdateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,policy-sets"`
+
+	/// The name of the policy set.
+	Name *string `jsonapi:"attr,name,omitempty"`
+
+	// The description of the policy set.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
+	// Whether or not the policy set is global.
+	Global *bool `jsonapi:"attr,global,omitempty"`
+}
+
+func (o PolicySetUpdateOptions) valid() error {
+	if o.Name != nil && !validStringID(o.Name) {
+		return errors.New("Invalid value for name")
+	}
+	return nil
+}
+
+// Update an existing policy set.
+func (s *policySets) Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &PolicySet{}
+	err = s.client.do(ctx, req, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, err
+}
+
+// PolicySetAddPoliciesOptions represents the options for adding policies to a policy set.
+type PolicySetAddPoliciesOptions struct {
+	/// The policies to add to the policy set.
+	Policies []*Policy
+}
+
+func (o PolicySetAddPoliciesOptions) valid() error {
+	if o.Policies == nil {
+		return errors.New("Policies is required")
+	}
+	if len(o.Policies) == 0 {
+		return errors.New("Must provide at least one policy")
+	}
+	return nil
+}
+
+// Add policies to a policy set
+func (s *policySets) AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("POST", u, options.Policies)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// PolicySetRemovePoliciesOptions represents the options for removing policies from a policy set.
+type PolicySetRemovePoliciesOptions struct {
+	/// The policies to remove from the policy set.
+	Policies []*Policy
+}
+
+func (o PolicySetRemovePoliciesOptions) valid() error {
+	if o.Policies == nil {
+		return errors.New("Policies is required")
+	}
+	if len(o.Policies) == 0 {
+		return errors.New("Must provide at least one policy")
+	}
+	return nil
+}
+
+// Remove policies from a policy set
+func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("DELETE", u, options.Policies)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// PolicySetAttachToWorkspacesOptions represents the options for attaching a policy set to workspaces.
+type PolicySetAttachToWorkspacesOptions struct {
+	/// The workspaces on which to attach the policy set.
+	Workspaces []*Workspace
+}
+
+func (o PolicySetAttachToWorkspacesOptions) valid() error {
+	if o.Workspaces == nil {
+		return errors.New("Workspaces is required")
+	}
+	if len(o.Workspaces) == 0 {
+		return errors.New("Must provide at least one workspace")
+	}
+	return nil
+}
+
+// Attach a policy set to workspaces
+func (s *policySets) AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("POST", u, options.Workspaces)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// PolicySetDetachFromWorkspacesOptions represents the options for detaching a policy set from workspaces.
+type PolicySetDetachFromWorkspacesOptions struct {
+	/// The workspaces from which to detach the policy set.
+	Workspaces []*Workspace
+}
+
+func (o PolicySetDetachFromWorkspacesOptions) valid() error {
+	if o.Workspaces == nil {
+		return errors.New("Workspaces is required")
+	}
+	if len(o.Workspaces) == 0 {
+		return errors.New("Must provide at least one workspace")
+	}
+	return nil
+}
+
+// Detach a policy set from workspaces
+func (s *policySets) DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("DELETE", u, options.Workspaces)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// Delete a policy set by its ID.
+func (s *policySets) Delete(ctx context.Context, policySetID string) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/vendor/github.com/hashicorp/go-tfe/run.go
+++ b/vendor/github.com/hashicorp/go-tfe/run.go
@@ -31,6 +31,9 @@ type Runs interface {
 	// Cancel a run by its ID.
 	Cancel(ctx context.Context, runID string, options RunCancelOptions) error
 
+	// Force-cancel a run by its ID.
+	ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error
+
 	// Discard a run by its ID.
 	Discard(ctx context.Context, runID string, options RunDiscardOptions) error
 }
@@ -45,18 +48,20 @@ type RunStatus string
 
 //List all available run statuses.
 const (
-	RunApplied        RunStatus = "applied"
-	RunApplying       RunStatus = "applying"
-	RunCanceled       RunStatus = "canceled"
-	RunConfirmed      RunStatus = "confirmed"
-	RunDiscarded      RunStatus = "discarded"
-	RunErrored        RunStatus = "errored"
-	RunPending        RunStatus = "pending"
-	RunPlanned        RunStatus = "planned"
-	RunPlanning       RunStatus = "planning"
-	RunPolicyChecked  RunStatus = "policy_checked"
-	RunPolicyChecking RunStatus = "policy_checking"
-	RunPolicyOverride RunStatus = "policy_override"
+	RunApplied            RunStatus = "applied"
+	RunApplying           RunStatus = "applying"
+	RunCanceled           RunStatus = "canceled"
+	RunConfirmed          RunStatus = "confirmed"
+	RunDiscarded          RunStatus = "discarded"
+	RunErrored            RunStatus = "errored"
+	RunPending            RunStatus = "pending"
+	RunPlanned            RunStatus = "planned"
+	RunPlannedAndFinished RunStatus = "planned_and_finished"
+	RunPlanning           RunStatus = "planning"
+	RunPolicyChecked      RunStatus = "policy_checked"
+	RunPolicyChecking     RunStatus = "policy_checking"
+	RunPolicyOverride     RunStatus = "policy_override"
+	RunPolicySoftFailed   RunStatus = "policy_soft_failed"
 )
 
 // RunSource represents a source type of a run.
@@ -77,16 +82,18 @@ type RunList struct {
 
 // Run represents a Terraform Enterprise run.
 type Run struct {
-	ID               string               `jsonapi:"primary,runs"`
-	Actions          *RunActions          `jsonapi:"attr,actions"`
-	CreatedAt        time.Time            `jsonapi:"attr,created-at,iso8601"`
-	HasChanges       bool                 `jsonapi:"attr,has-changes"`
-	IsDestroy        bool                 `jsonapi:"attr,is-destroy"`
-	Message          string               `jsonapi:"attr,message"`
-	Permissions      *RunPermissions      `jsonapi:"attr,permissions"`
-	Source           RunSource            `jsonapi:"attr,source"`
-	Status           RunStatus            `jsonapi:"attr,status"`
-	StatusTimestamps *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	ID                     string               `jsonapi:"primary,runs"`
+	Actions                *RunActions          `jsonapi:"attr,actions"`
+	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
+	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
+	HasChanges             bool                 `jsonapi:"attr,has-changes"`
+	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
+	Message                string               `jsonapi:"attr,message"`
+	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
+	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
+	Source                 RunSource            `jsonapi:"attr,source"`
+	Status                 RunStatus            `jsonapi:"attr,status"`
+	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -98,9 +105,10 @@ type Run struct {
 
 // RunActions represents the run actions.
 type RunActions struct {
-	IsCancelable  bool `json:"is-cancelable"`
-	IsConfirmable bool `json:"is-confirmable"`
-	IsDiscardable bool `json:"is-discardable"`
+	IsCancelable      bool `json:"is-cancelable"`
+	IsConfirmable     bool `json:"is-confirmable"`
+	IsDiscardable     bool `json:"is-discardable"`
+	IsForceCancelable bool `json:"is-force-cancelable"`
 }
 
 // RunPermissions represents the run permissions.
@@ -108,6 +116,7 @@ type RunPermissions struct {
 	CanApply        bool `json:"can-apply"`
 	CanCancel       bool `json:"can-cancel"`
 	CanDiscard      bool `json:"can-discard"`
+	CanForceCancel  bool `json:"can-force-cancel"`
 	CanForceExecute bool `json:"can-force-execute"`
 }
 
@@ -251,6 +260,27 @@ func (s *runs) Cancel(ctx context.Context, runID string, options RunCancelOption
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/cancel", url.QueryEscape(runID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// RunCancelOptions represents the options for force-canceling a run.
+type RunForceCancelOptions struct {
+	// An optional comment explaining the reason for the force-cancel.
+	Comment *string `json:"comment,omitempty"`
+}
+
+// ForceCancel is used to forcefully cancel a run by its ID.
+func (s *runs) ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error {
+	if !validStringID(&runID) {
+		return errors.New("Invalid value for run ID")
+	}
+
+	u := fmt.Sprintf("runs/%s/actions/force-cancel", url.QueryEscape(runID))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
 		return err

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -48,6 +48,9 @@ type Config struct {
 	// API token used to access the Terraform Enterprise API.
 	Token string
 
+	// Headers that will be added to every request.
+	Headers http.Header
+
 	// A custom HTTP client to use.
 	HTTPClient *http.Client
 }
@@ -58,6 +61,7 @@ func DefaultConfig() *Config {
 		Address:    os.Getenv("TFE_ADDRESS"),
 		BasePath:   DefaultBasePath,
 		Token:      os.Getenv("TFE_TOKEN"),
+		Headers:    make(http.Header),
 		HTTPClient: cleanhttp.DefaultPooledClient(),
 	}
 
@@ -66,16 +70,19 @@ func DefaultConfig() *Config {
 		config.Address = DefaultAddress
 	}
 
+	// Set the default user agent.
+	config.Headers.Set("User-Agent", userAgent)
+
 	return config
 }
 
 // Client is the Terraform Enterprise API client. It provides the basic
 // connectivity and configuration for accessing the TFE API.
 type Client struct {
-	baseURL   *url.URL
-	token     string
-	http      *http.Client
-	userAgent string
+	baseURL *url.URL
+	token   string
+	headers http.Header
+	http    *http.Client
 
 	Applies               Applies
 	ConfigurationVersions ConfigurationVersions
@@ -86,6 +93,7 @@ type Client struct {
 	Plans                 Plans
 	Policies              Policies
 	PolicyChecks          PolicyChecks
+	PolicySets            PolicySets
 	Runs                  Runs
 	SSHKeys               SSHKeys
 	StateVersions         StateVersions
@@ -113,6 +121,9 @@ func NewClient(cfg *Config) (*Client, error) {
 		if cfg.Token != "" {
 			config.Token = cfg.Token
 		}
+		for k, v := range cfg.Headers {
+			config.Headers[k] = v
+		}
 		if cfg.HTTPClient != nil {
 			config.HTTPClient = cfg.HTTPClient
 		}
@@ -136,10 +147,10 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	// Create the client.
 	client := &Client{
-		baseURL:   baseURL,
-		token:     config.Token,
-		http:      config.HTTPClient,
-		userAgent: userAgent,
+		baseURL: baseURL,
+		token:   config.Token,
+		headers: config.Headers,
+		http:    config.HTTPClient,
 	}
 
 	// Create the services.
@@ -152,6 +163,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Plans = &plans{client: client}
 	client.Policies = &policies{client: client}
 	client.PolicyChecks = &policyChecks{client: client}
+	client.PolicySets = &policySets{client: client}
 	client.Runs = &runs{client: client}
 	client.SSHKeys = &sshKeys{client: client}
 	client.StateVersions = &stateVersions{client: client}
@@ -208,6 +220,11 @@ func (c *Client) newRequest(method, path string, v interface{}) (*http.Request, 
 		Host:       u.Host,
 	}
 
+	// Set default headers.
+	for k, v := range c.headers {
+		req.Header[k] = v
+	}
+
 	switch method {
 	case "GET":
 		req.Header.Set("Accept", "application/vnd.api+json")
@@ -249,9 +266,8 @@ func (c *Client) newRequest(method, path string, v interface{}) (*http.Request, 
 		}
 	}
 
-	// Set required headers.
+	// Set the authorization header.
 	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("User-Agent", c.userAgent)
 
 	return req, nil
 }

--- a/vendor/github.com/hashicorp/go-tfe/workspace.go
+++ b/vendor/github.com/hashicorp/go-tfe/workspace.go
@@ -72,6 +72,7 @@ type Workspace struct {
 	WorkingDirectory     string                `jsonapi:"attr,working-directory"`
 
 	// Relations
+	CurrentRun   *Run          `jsonapi:"relation,current-run"`
 	Organization *Organization `jsonapi:"relation,organization"`
 	SSHKey       *SSHKey       `jsonapi:"relation,ssh-key"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -385,10 +385,10 @@
 			"revisionTime": "2018-07-12T07:51:27Z"
 		},
 		{
-			"checksumSHA1": "V2A92CHPEiPIsU4Wepl0ukznka8=",
+			"checksumSHA1": "3C1ALhVPpNvXgN/AKvNB4PPYOkI=",
 			"path": "github.com/hashicorp/go-tfe",
-			"revision": "cca0c15746d89219f9732f6c07d267827fef25cd",
-			"revisionTime": "2018-09-20T19:42:22Z"
+			"revision": "6a3f66e1cccdaba86473028d07abc9a0770e5ebb",
+			"revisionTime": "2018-11-07T18:04:27Z"
 		},
 		{
 			"checksumSHA1": "85XUnluYJL7F55ptcwdmN8eSOsk=",

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_sentinel_policy"
+sidebar_current: "docs-resource-tfe-sentinel-policy"
+description: |-
+  Sentinel Policy as Code is an embedded policy as code framework integrated with Terraform Enterprise.
+---
+
+# tfe_policy_set
+
+Sentinel Policy as Code is an embedded policy as code framework integrated
+with Terraform Enterprise.
+
+Policy sets are configured on a per-organization level, and allow organization
+owners to choose which policies are enforced on which workspaces.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_policy_set" "test" {
+  name = "my-policy-set"
+  description = "A brand new policy set"
+  organization = "my-org-name"
+  policy_ids = ["${tfe_sentinel_policy.test.id}"]
+  workspace_external_ids = ["${tfe_workspace.test.id}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the policy set.
+* `description` - (Optional) A description of the policy set's purpose.
+* `global` - (Optional) Whether or not policies in this set will apply to
+  all workspaces. Defaults to `false`. This value _must not_ be provided if `workspace_external_ids` are provided.
+* `organization` - (Required) Name of the organization.
+* `policy_ids` - (Required) A list of Sentinel policy IDs.
+* `workspace_external_ids` - (Optional) A list of workspace external IDs. If the policy set is
+  `global`, this value _must not_ be provided.
+
+## Attributes Reference
+
+* `id` - The ID of the policy set.
+
+## Import
+
+Policy sets can be imported; use `<POLICY SET ID>` as the import ID. For example:
+
+```shell
+terraform import tfe_policy_set.test polset-wAs3zYmWAhYK7peR
+```

--- a/website/docs/r/sentinel_policy.html.markdown
+++ b/website/docs/r/sentinel_policy.html.markdown
@@ -22,6 +22,7 @@ Basic usage:
 ```hcl
 resource "tfe_sentinel_policy" "test" {
   name = "my-policy-name"
+  description = "This policy always passes"
   organization = "my-org-name"
   policy = "main = rule { true }"
   enforce_mode = "hard-mandatory"
@@ -33,6 +34,7 @@ resource "tfe_sentinel_policy" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Name of the policy.
+* `description` - (Optional) A description of the policy's purpose.
 * `organization` - (Required) Name of the organization.
 * `policy` - (Required) The actual policy itself.
 * `enforce_mode` - (Required) The enforcement level of the policy. Valid

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -21,6 +21,10 @@
                             <a href="/docs/providers/tfe/r/organization_token.html">tfe_organization_token</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-resource-tfe-policy-set") %>>
+                            <a href="/docs/providers/tfe/r/policy_set.html">tfe_policy_set</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-resource-tfe-sentinel-policy") %>>
                             <a href="/docs/providers/tfe/r/sentinel_policy.html">tfe_sentinel_policy</a>
                         </li>


### PR DESCRIPTION
Now that policy sets have been enabled, we can add support for it to the Terraform provider for TFE. We might want to wait until we've finalized the feature in TFE before this is merged, but we can at least get the feedback loop started!