### PR TITLE
Make switching global on/off a bit cleaner

### DIFF
--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -161,6 +161,7 @@ func TestAccTFEPolicySetUpdate_global(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A global set populated with some policies"),
 					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "true"),
 					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "0"),
 				),
 			},
 		},
@@ -184,6 +185,7 @@ func TestAccTFEPolicySetUpdate_workspaceSwap(t *testing.T) {
 					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "description", "A global set populated with some policies"),
 					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "global", "true"),
 					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "policy_ids.#", "1"),
+					resource.TestCheckResourceAttr("tfe_policy_set.my_set", "workspace_external_ids.#", "0"),
 				),
 			},
 

--- a/tfe/resource_tfe_sentinel_policy.go
+++ b/tfe/resource_tfe_sentinel_policy.go
@@ -136,22 +136,21 @@ func resourceTFESentinelPolicyRead(d *schema.ResourceData, meta interface{}) err
 func resourceTFESentinelPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	changeEnforce := d.HasChange("enforce_mode")
-	if d.HasChange("description") || changeEnforce {
+	if d.HasChange("description") || d.HasChange("enforce_mode") {
 		// Create a new options struct.
 		options := tfe.PolicyUpdateOptions{}
 
-		if changeEnforce {
+		if desc, ok := d.GetOk("description"); ok {
+			options.Description = tfe.String(desc.(string))
+		}
+
+		if d.HasChange("enforce_mode") {
 			options.Enforce = []*tfe.EnforcementOptions{
 				&tfe.EnforcementOptions{
 					Path: tfe.String(d.Get("name").(string) + ".sentinel"),
 					Mode: tfe.EnforcementMode(tfe.EnforcementLevel(d.Get("enforce_mode").(string))),
 				},
 			}
-		}
-
-		if desc, ok := d.GetOk("description"); ok {
-			options.Description = tfe.String(desc.(string))
 		}
 
 		log.Printf("[DEBUG] Update configuration for sentinel policy: %s", d.Id())

--- a/vendor/github.com/hashicorp/go-tfe/go.mod
+++ b/vendor/github.com/hashicorp/go-tfe/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.0
-	github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6
+	github.com/hashicorp/go-retryablehttp v0.5.0
 	github.com/hashicorp/go-slug v0.1.0
 	github.com/hashicorp/go-uuid v1.0.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/vendor/github.com/hashicorp/go-tfe/go.sum
+++ b/vendor/github.com/hashicorp/go-tfe/go.sum
@@ -4,8 +4,8 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6 h1:qCv4319q2q7XKn0MQbi8p37hsJ+9Xo8e6yojA73JVxk=
-github.com/hashicorp/go-retryablehttp v0.0.0-20180718195005-e651d75abec6/go.mod h1:fXcdFsQoipQa7mwORhKad5jmDCeSy/RCGzWA08PO0lM=
+github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=
+github.com/hashicorp/go-retryablehttp v0.5.0/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-slug v0.1.0 h1:MJGEiOwRGrQCBmMMZABHqIESySFJ4ajrsjgDI4/aFI0=
 github.com/hashicorp/go-slug v0.1.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=

--- a/vendor/github.com/hashicorp/go-tfe/logreader.go
+++ b/vendor/github.com/hashicorp/go-tfe/logreader.go
@@ -63,6 +63,11 @@ func (r *LogReader) read(l []byte) (int, error) {
 	}
 	req = req.WithContext(r.ctx)
 
+	// Attach the default headers.
+	for k, v := range r.client.headers {
+		req.Header[k] = v
+	}
+
 	// Retrieve the next chunk.
 	resp, err := r.client.http.HTTPClient.Do(req)
 	if err != nil {

--- a/vendor/github.com/hashicorp/go-tfe/policy_set.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_set.go
@@ -16,7 +16,7 @@ var _ PolicySets = (*policySets)(nil)
 //
 // TFE API docs: https://www.terraform.io/docs/enterprise/api/policies.html
 type PolicySets interface {
-	// List all the policy sets for a given organization
+	// List all the policy sets for a given organization.
 	List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error)
 
 	// Create a policy set and associate it with an organization.
@@ -34,11 +34,11 @@ type PolicySets interface {
 	// Remove policies from a policy set.
 	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
 
-	// Attach a policy set to workspaces.
-	AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error
+	// Add workspaces to a policy set.
+	AddWorkspaces(ctx context.Context, policySetID string, options PolicySetAddWorkspacesOptions) error
 
-	// Detach a policy set from workspaces.
-	DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error
+	// Remove workspaces from a policy set.
+	RemoveWorkspaces(ctx context.Context, policySetID string, options PolicySetRemoveWorkspacesOptions) error
 
 	// Delete a policy set by its ID.
 	Delete(ctx context.Context, policyID string) error
@@ -49,7 +49,7 @@ type policySets struct {
 	client *Client
 }
 
-// PolicySetList represents a list of policy sets..
+// PolicySetList represents a list of policy sets.
 type PolicySetList struct {
 	*Pagination
 	Items []*PolicySet
@@ -80,7 +80,7 @@ type PolicySetListOptions struct {
 	Search *string `url:"search[name],omitempty"`
 }
 
-// List all the policies for a given organization
+// List all the policies for a given organization.
 func (s *policySets) List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error) {
 	if !validStringID(&organization) {
 		return nil, errors.New("invalid value for organization")
@@ -118,7 +118,7 @@ type PolicySetCreateOptions struct {
 	// The initial members of the policy set.
 	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
 
-	// The initial list of workspaces the policy set should be attached to.
+	// The initial list of workspaces for which the policy set should be enforced.
 	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`
 }
 
@@ -229,7 +229,8 @@ func (s *policySets) Update(ctx context.Context, policySetID string, options Pol
 	return ps, err
 }
 
-// PolicySetAddPoliciesOptions represents the options for adding policies to a policy set.
+// PolicySetAddPoliciesOptions represents the options for adding policies
+// to a policy set.
 type PolicySetAddPoliciesOptions struct {
 	/// The policies to add to the policy set.
 	Policies []*Policy
@@ -263,7 +264,8 @@ func (s *policySets) AddPolicies(ctx context.Context, policySetID string, option
 	return s.client.do(ctx, req, nil)
 }
 
-// PolicySetRemovePoliciesOptions represents the options for removing policies from a policy set.
+// PolicySetRemovePoliciesOptions represents the options for removing
+// policies from a policy set.
 type PolicySetRemovePoliciesOptions struct {
 	/// The policies to remove from the policy set.
 	Policies []*Policy
@@ -297,13 +299,14 @@ func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, opt
 	return s.client.do(ctx, req, nil)
 }
 
-// PolicySetAttachToWorkspacesOptions represents the options for attaching a policy set to workspaces.
-type PolicySetAttachToWorkspacesOptions struct {
-	/// The workspaces on which to attach the policy set.
+// PolicySetAddWorkspacesOptions represents the options for adding workspaces
+// to a policy set.
+type PolicySetAddWorkspacesOptions struct {
+	/// The workspaces to add to the policy set.
 	Workspaces []*Workspace
 }
 
-func (o PolicySetAttachToWorkspacesOptions) valid() error {
+func (o PolicySetAddWorkspacesOptions) valid() error {
 	if o.Workspaces == nil {
 		return errors.New("workspaces is required")
 	}
@@ -313,8 +316,8 @@ func (o PolicySetAttachToWorkspacesOptions) valid() error {
 	return nil
 }
 
-// Attach a policy set to workspaces
-func (s *policySets) AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error {
+// Add workspaces to a policy set.
+func (s *policySets) AddWorkspaces(ctx context.Context, policySetID string, options PolicySetAddWorkspacesOptions) error {
 	if !validStringID(&policySetID) {
 		return errors.New("invalid value for policy set ID")
 	}
@@ -331,13 +334,14 @@ func (s *policySets) AttachToWorkspaces(ctx context.Context, policySetID string,
 	return s.client.do(ctx, req, nil)
 }
 
-// PolicySetDetachFromWorkspacesOptions represents the options for detaching a policy set from workspaces.
-type PolicySetDetachFromWorkspacesOptions struct {
-	/// The workspaces from which to detach the policy set.
+// PolicySetRemoveWorkspacesOptions represents the options for removing
+// workspaces from a policy set.
+type PolicySetRemoveWorkspacesOptions struct {
+	/// The workspaces to remove from the policy set.
 	Workspaces []*Workspace
 }
 
-func (o PolicySetDetachFromWorkspacesOptions) valid() error {
+func (o PolicySetRemoveWorkspacesOptions) valid() error {
 	if o.Workspaces == nil {
 		return errors.New("workspaces is required")
 	}
@@ -347,8 +351,8 @@ func (o PolicySetDetachFromWorkspacesOptions) valid() error {
 	return nil
 }
 
-// Detach a policy set from workspaces
-func (s *policySets) DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error {
+// Remove workspaces from a policy set.
+func (s *policySets) RemoveWorkspaces(ctx context.Context, policySetID string, options PolicySetRemoveWorkspacesOptions) error {
 	if !validStringID(&policySetID) {
 		return errors.New("invalid value for policy set ID")
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -391,10 +391,10 @@
 			"revisionTime": "2018-07-12T07:51:27Z"
 		},
 		{
-			"checksumSHA1": "SSpagWxXN+FGZBMC12N8AfzLkDM=",
+			"checksumSHA1": "CMhkgtN9SjmPaGr4gPTqf68THoQ=",
 			"path": "github.com/hashicorp/go-tfe",
-			"revision": "150f2f4faab9a204095ad30a124971db8a7dc0f9",
-			"revisionTime": "2018-11-13T09:27:22Z"
+			"revision": "c27cad6e3b38809253bf33e97ff832d4d4b744b9",
+			"revisionTime": "2018-11-13T19:56:35Z"
 		},
 		{
 			"checksumSHA1": "85XUnluYJL7F55ptcwdmN8eSOsk=",


### PR DESCRIPTION
There is no need to explicitly remove the attached workspaces when setting `global = true`.