### PR TITLE
Add organization_access to Team resource

### DIFF
--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -25,6 +25,12 @@ func TestAccTFETeam_basic(t *testing.T) {
 					testAccCheckTFETeamAttributes(team),
 					resource.TestCheckResourceAttr(
 						"tfe_team.foobar", "name", "team-test"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_policies", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_workspaces", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_team.foobar", "organization_access.0.manage_vcs_settings", "true"),
 				),
 			},
 		},
@@ -86,6 +92,18 @@ func testAccCheckTFETeamAttributes(
 		if team.Name != "team-test" {
 			return fmt.Errorf("Bad name: %s", team.Name)
 		}
+		// expectedOrganizationAccess := tfe.OrganizationAccess{
+		// 	ManagePolicies:    true,
+		// 	ManageWorkspaces:  false,
+		// 	ManageVCSSettings: true,
+		// }
+		// if team.OrganizationAccess != &expectedOrganizationAccess {
+		// 	return fmt.Errorf(
+		// 		"Expected OrganizationAccess: %s\nGot OrganizationAccess: %s",
+		// 		expectedOrganizationAccess,
+		// 		team.OrganizationAccess,
+		// 	)
+		// }
 		return nil
 	}
 }

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -120,4 +120,9 @@ resource "tfe_organization" "foobar" {
 resource "tfe_team" "foobar" {
   name = "team-test"
   organization = "${tfe_organization.foobar.id}"
+  organization_access {
+    manage_policies = true
+    manage_workspaces = false
+    manage_vcs_settings = true
+  }
 }`


### PR DESCRIPTION
Also adds updating to teams, now that we have more than just a name that can be directly updated instead of recreating the whole team.