### PR TITLE
vendor: github.com/hashicorp/go-tfe@v0.3.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-getter v1.0.1 // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a // indirect
-	github.com/hashicorp/go-tfe v0.0.0-20190118183033-437fc3949d85
+	github.com/hashicorp/go-tfe v0.3.8
 	github.com/hashicorp/go-version v1.1.0 // indirect
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl2 v0.0.0-20190128103256-93fb31f28b86 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-slug v0.2.0 h1:MVdZAkTmDsUi1AT+3NQDsn8n3ssnVSIHwiM6RcUHvE8=
 github.com/hashicorp/go-slug v0.2.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb9JUF+0km4=
-github.com/hashicorp/go-tfe v0.0.0-20190118183033-437fc3949d85 h1:Z9y0DBxEsRV5rqxK+H7qd1SO1jUgSsNGPbC0xzb+Ys4=
-github.com/hashicorp/go-tfe v0.0.0-20190118183033-437fc3949d85/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
+github.com/hashicorp/go-tfe v0.3.8 h1:pUqxmnhZ7Dj3biugEEo2oGZ758zVQy70lx8p7p4JREY=
+github.com/hashicorp/go-tfe v0.3.8/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -251,13 +251,8 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 
 // configureLimiter configures the rate limiter.
 func (c *Client) configureLimiter() error {
-	u, err := c.baseURL.Parse("/")
-	if err != nil {
-		return err
-	}
-
 	// Create a new request.
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", c.baseURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -266,6 +261,7 @@ func (c *Client) configureLimiter() error {
 	for k, v := range c.headers {
 		req.Header[k] = v
 	}
+	req.Header.Set("Accept", "application/vnd.api+json")
 
 	// Make a single request to retrieve the rate limit headers.
 	resp, err := c.http.HTTPClient.Do(req)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -83,7 +83,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.2.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.0.0-20190118183033-437fc3949d85
+# github.com/hashicorp/go-tfe v0.3.8
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
This is to align versions of `go-tfe` in TFE provider and Terraform's `v0.11` and make it easier to pull latest `v0.11` in.

Related: https://github.com/hashicorp/terraform/pull/20310