### PR TITLE
Add a check when migrating vcs_repo from a set to a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.8.0 (Unreleased)
+## 0.7.1 (Unreleased)
+
+BUG FIXES:
+
+* r/tfe_workspace: Add a check when migrating `vcs_repo` from a set to a list [GH-64]
+
 ## 0.7.0 (February 14, 2019)
 
 ENHANCEMENTS:

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -246,11 +246,11 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 
 		// Get and assert the VCS repo configuration block.
 		if v, ok := d.GetOk("vcs_repo"); ok {
-			vcsRepo := v.([]interface{})[0].(map[string]interface{})
-
-			// Only set the branch if one is configured.
-			if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
-				vcsConfig["branch"] = workspace.VCSRepo.Branch
+			if vcsRepo, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+				// Only set the branch if one is configured.
+				if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
+					vcsConfig["branch"] = workspace.VCSRepo.Branch
+				}
 			}
 		}
 


### PR DESCRIPTION
In previous versions we used a set for the `vcs_repo` attribute. This was updated to a list which could cause migration issues. This is mitigated by adding an additional check.

Fixes #63