### PR TITLE
Allow setting hostname via TFE_HOSTNAME ENV variable

### DIFF
--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -50,7 +50,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: descriptions["hostname"],
-				Default:     defaultHostname,
+				DefaultFunc: schema.EnvDefaultFunc("TFE_HOSTNAME", defaultHostname),
 			},
 
 			"token": {


### PR DESCRIPTION
This addresses one part of https://github.com/terraform-providers/terraform-provider-tfe/issues/31 (just the hostname part, not credentials).

There doesn't seem to be _any_ way to set the hostname dynamically now, as opposed to credentials.