### PR TITLE
 Add owners_team_saml_role_id organization option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/hashicorp/go-getter v1.0.1 // indirect
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a // indirect
-	github.com/hashicorp/go-tfe v0.3.8
-	github.com/hashicorp/go-version v1.1.0 // indirect
+	github.com/hashicorp/go-tfe v0.3.9
+	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/hcl2 v0.0.0-20190128103256-93fb31f28b86 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/hashicorp/go-slug v0.2.0/go.mod h1:+zDycQOzGqOqMW7Kn2fp9vz/NtqpMLQlgb
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-tfe v0.3.8 h1:pUqxmnhZ7Dj3biugEEo2oGZ758zVQy70lx8p7p4JREY=
 github.com/hashicorp/go-tfe v0.3.8/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
+github.com/hashicorp/go-tfe v0.3.9 h1:8tnu45eYDqLVNGtnfaN0UxurU+++X/T4SWq3qT4OKsQ=
+github.com/hashicorp/go-tfe v0.3.9/go.mod h1:LHLchj07PCYgQqcyE5Sz+g4zrMNW+nALKbiSNTZedEs=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -52,6 +52,11 @@ func resourceTFEOrganization() *schema.Resource {
 					false,
 				),
 			},
+
+			"owners_team_saml_role_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -99,6 +104,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("session_timeout_minutes", org.SessionTimeout)
 	d.Set("session_remember_minutes", org.SessionRemember)
 	d.Set("collaborator_auth_policy", string(org.CollaboratorAuthPolicy))
+	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
 
 	return nil
 }
@@ -125,6 +131,11 @@ func resourceTFEOrganizationUpdate(d *schema.ResourceData, meta interface{}) err
 	// If collaborator_auth_policy is supplied, set it using the options struct.
 	if authPolicy, ok := d.GetOk("collaborator_auth_policy"); ok {
 		options.CollaboratorAuthPolicy = tfe.AuthPolicy(tfe.AuthPolicyType(authPolicy.(string)))
+	}
+
+	// If owners_team_saml_role_id is supplied, set it using the options struct.
+	if ownersTeamSAMLRoleID, ok := d.GetOk("owners_team_saml_role_id"); ok {
+		options.OwnersTeamSAMLRoleID = tfe.String(ownersTeamSAMLRoleID.(string))
 	}
 
 	log.Printf("[DEBUG] Update configuration of organization: %s", d.Id())

--- a/tfe/resource_tfe_organization.go
+++ b/tfe/resource_tfe_organization.go
@@ -103,7 +103,7 @@ func resourceTFEOrganizationRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("email", org.Email)
 	d.Set("session_timeout_minutes", org.SessionTimeout)
 	d.Set("session_remember_minutes", org.SessionRemember)
-	d.Set("collaborator_auth_policy", string(org.CollaboratorAuthPolicy))
+	d.Set("collaborator_auth_policy", org.CollaboratorAuthPolicy)
 	d.Set("owners_team_saml_role_id", org.OwnersTeamSAMLRoleID)
 
 	return nil

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -75,7 +75,7 @@ func TestAccTFEOrganization_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "owners_team_saml_role_id", "owners-updated"),
+						"tfe_organization.foobar", "owners_team_saml_role_id", "owners"),
 				),
 			},
 		},
@@ -172,7 +172,7 @@ func testAccCheckTFEOrganizationAttributesUpdated(
 			return fmt.Errorf("Bad auth policy: %s", org.CollaboratorAuthPolicy)
 		}
 
-		if org.OwnersTeamSAMLRoleID != "owners-updated" {
+		if org.OwnersTeamSAMLRoleID != "owners" {
 			return fmt.Errorf("Bad owners team SAML role ID: %s", org.OwnersTeamSAMLRoleID)
 		}
 
@@ -213,5 +213,5 @@ resource "tfe_organization" "foobar" {
   email                    = "admin-updated@company.com"
   session_timeout_minutes  = 3600
   session_remember_minutes = 3600
-  owners_team_saml_role_id = "owners-updated"
+  owners_team_saml_role_id = "owners"
 }`

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -29,8 +29,6 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
-					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "owners_team_saml_role_id", "owners"),
 				),
 			},
 		},

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -29,6 +29,8 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "owners_team_saml_role_id", "owners"),
 				),
 			},
 		},
@@ -74,6 +76,8 @@ func TestAccTFEOrganization_update(t *testing.T) {
 						"tfe_organization.foobar", "session_remember_minutes", "3600"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "collaborator_auth_policy", "password"),
+					resource.TestCheckResourceAttr(
+						"tfe_organization.foobar", "owners_team_saml_role_id", "owners-updated"),
 				),
 			},
 		},
@@ -170,6 +174,10 @@ func testAccCheckTFEOrganizationAttributesUpdated(
 			return fmt.Errorf("Bad auth policy: %s", org.CollaboratorAuthPolicy)
 		}
 
+		if org.OwnersTeamSAMLRoleID != "owners-updated" {
+			return fmt.Errorf("Bad owners team SAML role ID: %s", org.OwnersTeamSAMLRoleID)
+		}
+
 		return nil
 	}
 }
@@ -207,4 +215,5 @@ resource "tfe_organization" "foobar" {
   email                    = "admin-updated@company.com"
   session_timeout_minutes  = 3600
   session_remember_minutes = 3600
+  owners_team_saml_role_id = "owners-updated"
 }`

--- a/vendor/github.com/hashicorp/go-tfe/organization.go
+++ b/vendor/github.com/hashicorp/go-tfe/organization.go
@@ -80,7 +80,7 @@ type Organization struct {
 	CreatedAt              time.Time                `jsonapi:"attr,created-at,iso8601"`
 	Email                  string                   `jsonapi:"attr,email"`
 	EnterprisePlan         EnterprisePlanType       `jsonapi:"attr,enterprise-plan"`
-	OwnersTeamSamlRoleID   string                   `jsonapi:"attr,owners-team-saml-role-id"`
+	OwnersTeamSAMLRoleID   string                   `jsonapi:"attr,owners-team-saml-role-id"`
 	Permissions            *OrganizationPermissions `jsonapi:"attr,permissions"`
 	SAMLEnabled            bool                     `jsonapi:"attr,saml-enabled"`
 	SessionRemember        int                      `jsonapi:"attr,session-remember"`
@@ -157,6 +157,18 @@ type OrganizationCreateOptions struct {
 
 	// Admin email address.
 	Email *string `jsonapi:"attr,email"`
+
+	// Session expiration (minutes).
+	SessionRemember *int `jsonapi:"attr,session-remember,omitempty"`
+
+	// Session timeout after inactivity (minutes).
+	SessionTimeout *int `jsonapi:"attr,session-timeout,omitempty"`
+
+	// Authentication policy.
+	CollaboratorAuthPolicy *AuthPolicyType `jsonapi:"attr,collaborator-auth-policy,omitempty"`
+
+	// The name of the "owners" team
+	OwnersTeamSAMLRoleID *string `jsonapi:"attr,owners-team-saml-role-id,omitempty"`
 }
 
 func (o OrganizationCreateOptions) valid() error {
@@ -235,6 +247,9 @@ type OrganizationUpdateOptions struct {
 
 	// Authentication policy.
 	CollaboratorAuthPolicy *AuthPolicyType `jsonapi:"attr,collaborator-auth-policy,omitempty"`
+
+	// The name of the "owners" team
+	OwnersTeamSAMLRoleID *string `jsonapi:"attr,owners-team-saml-role-id,omitempty"`
 }
 
 // Update attributes of an existing organization.

--- a/vendor/github.com/hashicorp/go-tfe/run.go
+++ b/vendor/github.com/hashicorp/go-tfe/run.go
@@ -122,10 +122,16 @@ type RunPermissions struct {
 
 // RunStatusTimestamps holds the timestamps for individual run statuses.
 type RunStatusTimestamps struct {
-	ErroredAt  time.Time `json:"errored-at"`
-	FinishedAt time.Time `json:"finished-at"`
-	QueuedAt   time.Time `json:"queued-at"`
-	StartedAt  time.Time `json:"started-at"`
+	ErroredAt            time.Time `json:"errored-at"`
+	FinishedAt           time.Time `json:"finished-at"`
+	QueuedAt             time.Time `json:"queued-at"`
+	StartedAt            time.Time `json:"started-at"`
+	ApplyingAt           time.Time `json:"applying-at"`
+	AppliedAt            time.Time `json:"applied-at"`
+	PlanningAt           time.Time `json:"planning-at"`
+	PlannedAt            time.Time `json:"planned-at"`
+	PlannedAndFinishedAt time.Time `json:"planned-and-finished-at"`
+	PlanQueuabledAt      time.Time `json:"plan-queueable-at"`
 }
 
 // RunListOptions represents the options for listing runs.

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -35,9 +35,6 @@ const (
 )
 
 var (
-	// random is used to generate pseudo-random numbers.
-	random = rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	// ErrWorkspaceLocked is returned when trying to lock a
 	// locked workspace.
 	ErrWorkspaceLocked = errors.New("workspace already locked")
@@ -232,8 +229,11 @@ func rateLimitRetry(ctx context.Context, resp *http.Response, err error) (bool, 
 // the reset time retrieved from the headers. But if the final wait time is
 // less then min, min will be used instead.
 func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	// rnd is used to generate pseudo-random numbers.
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	// First create some jitter bounded by the min and max durations.
-	jitter := time.Duration(rand.Float64() * float64(max-min))
+	jitter := time.Duration(rnd.Float64() * float64(max-min))
 
 	if resp != nil {
 		if v := resp.Header.Get(headerRateReset); v != "" {

--- a/vendor/github.com/hashicorp/go-tfe/workspace.go
+++ b/vendor/github.com/hashicorp/go-tfe/workspace.go
@@ -31,6 +31,9 @@ type Workspaces interface {
 	// Delete a workspace by its name.
 	Delete(ctx context.Context, organization string, workspace string) error
 
+	// RemoveVCSConnection from a workspace.
+	RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error)
+
 	// Lock a workspace by its ID.
 	Lock(ctx context.Context, workspaceID string, options WorkspaceLockOptions) (*Workspace, error)
 
@@ -331,6 +334,41 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 	}
 
 	return s.client.do(ctx, req, nil)
+}
+
+// workspaceRemoveVCSConnectionOptions
+type workspaceRemoveVCSConnectionOptions struct {
+	ID      string          `jsonapi:"primary,workspaces"`
+	VCSRepo *VCSRepoOptions `jsonapi:"attr,vcs-repo"`
+}
+
+// RemoveVCSConnection from a workspace.
+func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+	if !validStringID(&workspace) {
+		return nil, errors.New("invalid value for workspace")
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/workspaces/%s",
+		url.QueryEscape(organization),
+		url.QueryEscape(workspace),
+	)
+
+	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
 }
 
 // WorkspaceLockOptions represents the options for locking a workspace.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -83,7 +83,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.2.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.8
+# github.com/hashicorp/go-tfe v0.3.9
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.0
 github.com/hashicorp/go-uuid
@@ -116,6 +116,7 @@ github.com/hashicorp/hil/scanner
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.11.12-beta1.0.20190212191339-ee1f8f9362f3
 github.com/hashicorp/terraform/plugin
+github.com/hashicorp/terraform/helper/logging
 github.com/hashicorp/terraform/helper/schema
 github.com/hashicorp/terraform/helper/validation
 github.com/hashicorp/terraform/svchost
@@ -141,7 +142,6 @@ github.com/hashicorp/terraform/registry
 github.com/hashicorp/terraform/registry/regsrc
 github.com/hashicorp/terraform/registry/response
 github.com/hashicorp/terraform/helper/config
-github.com/hashicorp/terraform/helper/logging
 # github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb
 github.com/hashicorp/yamux
 # github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -33,6 +33,7 @@ The following arguments are supported:
   `20160`.
 * `collaborator_auth_policy` - (Optional) Authentication policy (`password`
   or `two_factor_mandatory`). Defaults to `password`.
+* `owners_team_saml_role_id` - (Optional) The name of the "owners" team.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds the `owners_team_saml_role_id` option to the organization resource.

This uses the latest version of go-tfe. Update go-tfe to 0.3.9 is in f48f22f.

API docs are here: https://www.terraform.io/docs/enterprise/api/organizations.html
API client PR is https://github.com/hashicorp/go-tfe/pull/57