### PR TITLE
Make ssh_key_id in workspace not computed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ $ make testacc
 Testing
 -------
 A hostname and token must be provided in order to run the acceptance tests. We recomment configuring
-the required `credentials` in the [CLI config file](/docs/commands/cli-config.html#credentials).
+the required `credentials` in the [CLI config file](https://www.terraform.io/docs/commands/cli-config.html).

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -40,7 +40,6 @@ func resourceTFEWorkspace() *schema.Resource {
 			"ssh_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"queue_all_runs": {
@@ -232,8 +231,12 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("organization", workspace.Organization.Name)
 	}
 
-	if workspace.SSHKey != nil {
-		d.Set("ssh_key_id", workspace.SSHKey.ID)
+	// if the config sets ssh_key_id (even if "") set the
+	//  value from tfe's state, but otherwise ignore
+	if _, ok := d.GetOkExists("ssh_key_id"); ok {
+		if workspace.SSHKey != nil {
+			d.Set("ssh_key_id", workspace.SSHKey.ID)
+		}
 	}
 
 	var vcsRepo []interface{}

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -40,6 +40,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			"ssh_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 
 			"queue_all_runs": {
@@ -231,13 +232,11 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("organization", workspace.Organization.Name)
 	}
 
-	// if the config sets ssh_key_id (even if "") set the
-	//  value from tfe's state, but otherwise ignore
-	if _, ok := d.GetOkExists("ssh_key_id"); ok {
-		if workspace.SSHKey != nil {
-			d.Set("ssh_key_id", workspace.SSHKey.ID)
-		}
+	var sshKeyID string
+	if workspace.SSHKey != nil {
+		sshKeyID = workspace.SSHKey.ID
 	}
+	d.Set("ssh_key_id", sshKeyID)
 
 	var vcsRepo []interface{}
 	if workspace.VCSRepo != nil {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -241,28 +241,11 @@ func TestAccTFEWorkspace_sshKey(t *testing.T) {
 			},
 
 			{
-				Config: testAccTFEWorkspace_basic,
+				Config: testAccTFEWorkspace_noSSHKey,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFEWorkspaceExists(
 						"tfe_workspace.foobar", workspace),
 					testAccCheckTFEWorkspaceAttributes(workspace),
-					// as the ssh_key_id key is *not* in the config,
-					// it should not be unset in state
-					resource.TestCheckResourceAttrSet(
-						"tfe_workspace.foobar", "ssh_key_id"),
-				),
-			},
-
-			{
-				Config: testAccTFEWorkspace_blankSshKey,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTFEWorkspaceExists(
-						"tfe_workspace.foobar", workspace),
-					testAccCheckTFEWorkspaceAttributes(workspace),
-					// as the ssh_key_id key is in the config, it should be
-					// set to the new value (even though it is blank)
-					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "ssh_key_id", ""),
 				),
 			},
 		},
@@ -403,10 +386,6 @@ func testAccCheckTFEWorkspaceAttributesUpdated(
 func testAccCheckTFEWorkspaceAttributesSSHKey(
 	workspace *tfe.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if workspace.Name != "workspace-ssh-key" {
-			return fmt.Errorf("Bad name: %s", workspace.Name)
-		}
-
 		if workspace.SSHKey == nil {
 			return fmt.Errorf("Bad SSH key: %v", workspace.SSHKey)
 		}
@@ -494,13 +473,13 @@ resource "tfe_ssh_key" "foobar" {
 }
 
 resource "tfe_workspace" "foobar" {
-  name         = "workspace-ssh-key"
+  name         = "workspace-test"
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
   ssh_key_id   = "${tfe_ssh_key.foobar.id}"
 }`
 
-const testAccTFEWorkspace_blankSshKey = `
+const testAccTFEWorkspace_noSSHKey = `
 resource "tfe_organization" "foobar" {
   name  = "terraform-test"
   email = "admin@company.com"
@@ -513,8 +492,7 @@ resource "tfe_ssh_key" "foobar" {
 }
 
 resource "tfe_workspace" "foobar" {
-  name         = "workspace-ssh-key"
+  name         = "workspace-test"
   organization = "${tfe_organization.foobar.id}"
   auto_apply   = true
-  ssh_key_id   = ""
 }`

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -48,7 +48,7 @@ The `vcs_repo` block supports:
   Default to `master`.
 * `ingress_submodules` - (Optional) Whether submodules should be fetched when
   cloning the VCS repository. Defaults to `false`.
-* `oauth_token_id` - (Required) Token ID of the VCS Connection (OAuth Conection Token) 
+* `oauth_token_id` - (Required) Token ID of the VCS Connection (OAuth Conection Token)
   to use.
 
 ## Attributes Reference


### PR DESCRIPTION
- Removes `Computed: true` from ssh_key_id definition in schema
- Adds `Default: ""` to ssh_key_id definition in schema
- Adds test
- Fixes link in documentation