### PR TITLE
[WIP] r/policy_set: add support for VCS policy sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ these values with the environment variables specified below: `TFE_HOSTNAME` and
 
 To run all tests, you will need to set the following environment variables:
 
-- `TFE_HOSTNAME`: the hostname of your test TFE instance; for example, `tfe-test.local`
-- `TFE_TOKEN`: a user token for an administrator account on your TFE instance
 - `GITHUB_TOKEN`: a GitHub personal access token, used to establish a VCS provider connection
+- `TFE_HOSTNAME`: the hostname of your test TFE instance; for example, `tfe-test.local`
+- `TFE_POLICY_SET_VCS_BRANCH`: a VCS branch, used to test policy sets
+- `TFE_POLICY_SET_VCS_PATH`: a VCS path, used to test policy sets
+- `TFE_TOKEN`: a user token for an administrator account on your TFE instance
 - `TFE_USER1` and `TFE_USER2`: the usernames of two pre-existing TFE users, for testing team membership
+- `TFE_VCS_IDENTIFIER`: a VCS identifier, used to test policy sets

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.17
+	github.com/hashicorp/go-tfe v0.3.18
 	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFMH0=
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
-github.com/hashicorp/go-tfe v0.3.17 h1:4n4Z1Kr5hXKI2ntJLyso9yYFHjSBVYRGgK8BG48H6OQ=
-github.com/hashicorp/go-tfe v0.3.17/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
+github.com/hashicorp/go-tfe v0.3.18 h1:Rhiq89MbHE1J5/fRnJBjBhh0cXykE0/hPvmpY3ra1Wk=
+github.com/hashicorp/go-tfe v0.3.18/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/tfe/provider_test.go
+++ b/tfe/provider_test.go
@@ -1,7 +1,6 @@
 package tfe
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -93,21 +92,15 @@ func TestProvider_versionConstraints(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if os.Getenv("GITHUB_TOKEN") == "" {
-		t.Fatal("GITHUB_TOKEN must be set for acceptance tests")
-	}
 	// The credentials must be provided by the CLI config file for testing.
 	if err := Provider().Configure(&terraform.ResourceConfig{}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
-func testAccCheckEnvVariables(t *testing.T, variableNames []string) {
-	for _, varName := range variableNames {
-		if os.Getenv(varName) == "" {
-			t.Fatal(fmt.Sprintf("%s must be set for this test", varName))
-		}
-	}
-}
-
 var GITHUB_TOKEN = os.Getenv("GITHUB_TOKEN")
+var TFE_POLICY_SET_VCS_BRANCH = os.Getenv("TFE_POLICY_SET_VCS_BRANCH")
+var TFE_POLICY_SET_VCS_PATH = os.Getenv("TFE_POLICY_SET_VCS_PATH")
+var TFE_USER1 = os.Getenv("TFE_USER1")
+var TFE_USER2 = os.Getenv("TFE_USER2")
+var TFE_VCS_IDENTIFIER = os.Getenv("TFE_VCS_IDENTIFIER")

--- a/tfe/resource_tfe_oauth_client_test.go
+++ b/tfe/resource_tfe_oauth_client_test.go
@@ -13,7 +13,12 @@ func TestAccTFEOAuthClient_basic(t *testing.T) {
 	oc := &tfe.OAuthClient{}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if GITHUB_TOKEN == "" {
+				t.Skip("Please set GITHUB_TOKEN to run this test")
+			}
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEOAuthClientDestroy,
 		Steps: []resource.TestStep{

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -43,10 +43,51 @@ func resourceTFEPolicySet() *schema.Resource {
 				ConflictsWith: []string{"workspace_external_ids"},
 			},
 
+			"vcs_repo": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"policy_ids"},
+				MinItems:      1,
+				MaxItems:      1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"identifier": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"branch": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"ingress_submodules": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"oauth_token_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"policies_path": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"policy_ids"},
+			},
+
 			"policy_ids": {
-				Type:     schema.TypeSet,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"vcs_repo", "policies_path"},
 			},
 
 			"workspace_external_ids": {
@@ -74,6 +115,26 @@ func resourceTFEPolicySetCreate(d *schema.ResourceData, meta interface{}) error 
 	// Process all configured options.
 	if desc, ok := d.GetOk("description"); ok {
 		options.Description = tfe.String(desc.(string))
+	}
+
+	// Get and assert the VCS repo configuration block.
+	if v, ok := d.GetOk("vcs_repo"); ok {
+		vcsRepo := v.([]interface{})[0].(map[string]interface{})
+
+		options.VCSRepo = &tfe.VCSRepoOptions{
+			Identifier:        tfe.String(vcsRepo["identifier"].(string)),
+			IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
+			OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
+		}
+
+		// Only set the branch if one is configured.
+		if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
+			options.VCSRepo.Branch = tfe.String(branch)
+		}
+	}
+
+	if policiesPath, ok := d.GetOk("policies_path"); ok {
+		options.PoliciesPath = tfe.String(policiesPath.(string))
 	}
 
 	for _, policyID := range d.Get("policy_ids").(*schema.Set).List() {
@@ -114,10 +175,35 @@ func resourceTFEPolicySetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("name", policySet.Name)
 	d.Set("description", policySet.Description)
 	d.Set("global", policySet.Global)
+	d.Set("policies_path", policySet.PoliciesPath)
 
 	if policySet.Organization != nil {
 		d.Set("organization", policySet.Organization.Name)
 	}
+
+	// Set VCS policy set options.
+	var vcsRepo []interface{}
+	if policySet.VCSRepo != nil {
+		vcsConfig := map[string]interface{}{
+			"identifier":         policySet.VCSRepo.Identifier,
+			"ingress_submodules": policySet.VCSRepo.IngressSubmodules,
+			"oauth_token_id":     policySet.VCSRepo.OAuthTokenID,
+		}
+
+		// Get and assert the VCS repo configuration block.
+		if v, ok := d.GetOk("vcs_repo"); ok {
+			if vcsRepo, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+				// Only set the branch if one is configured.
+				if branch, ok := vcsRepo["branch"].(string); ok && branch != "" {
+					vcsConfig["branch"] = policySet.VCSRepo.Branch
+				}
+			}
+		}
+
+		vcsRepo = append(vcsRepo, vcsConfig)
+	}
+
+	d.Set("vcs_repo", vcsRepo)
 
 	// Update the policies.
 	var policyIDs []interface{}

--- a/vendor/github.com/hashicorp/go-tfe/README.md
+++ b/vendor/github.com/hashicorp/go-tfe/README.md
@@ -136,6 +136,7 @@ tests:
 $ export TFE_ADDRESS=https://tfe.local
 $ export TFE_TOKEN=xxxxxxxxxxxxxxxxxxx
 $ export GITHUB_TOKEN=xxxxxxxxxxxxxxxx
+$ export GITHUB_IDENTIFIER=xxxxxxxxxxx
 ```
 
 In order for the tests relating to queuing and capacity to pass, FRQ should be

--- a/vendor/github.com/hashicorp/go-tfe/policy_set.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_set.go
@@ -28,10 +28,12 @@ type PolicySets interface {
 	// Update an existing policy set.
 	Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error)
 
-	// Add policies to a policy set.
+	// Add policies to a policy set. This function can only be used when
+	// there is no VCS repository associated with the policy set.
 	AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error
 
-	// Remove policies from a policy set.
+	// Remove policies from a policy set. This function can only be used
+	// when there is no VCS repository associated with the policy set.
 	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
 
 	// Add workspaces to a policy set.
@@ -61,7 +63,9 @@ type PolicySet struct {
 	Name           string    `jsonapi:"attr,name"`
 	Description    string    `jsonapi:"attr,description"`
 	Global         bool      `jsonapi:"attr,global"`
+	PoliciesPath   string    `jsonapi:"attr,policies-path"`
 	PolicyCount    int       `jsonapi:"attr,policy-count"`
+	VCSRepo        *VCSRepo  `jsonapi:"attr,vcs-repo"`
 	WorkspaceCount int       `jsonapi:"attr,workspace-count"`
 	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt      time.Time `jsonapi:"attr,updated-at,iso8601"`
@@ -115,8 +119,20 @@ type PolicySetCreateOptions struct {
 	// Whether or not the policy set is global.
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
+	// The sub-path within the attached VCS repository to ingress. All
+	// files and directories outside of this sub-path will be ignored.
+	// This option may only be specified when a VCS repo is present.
+	PoliciesPath *string `jsonapi:"attr,policies-path,omitempty"`
+
 	// The initial members of the policy set.
 	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
+
+	// VCS repository information. When present, the policies and
+	// configuration will be sourced from the specified VCS repository
+	// instead of being defined within the policy set itself. Note that
+	// this option is mutually exclusive with the Policies option and
+	// both cannot be used at the same time.
+	VCSRepo *VCSRepoOptions `jsonapi:"attr,vcs-repo,omitempty"`
 
 	// The initial list of workspaces for which the policy set should be enforced.
 	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.3.0
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.17
+# github.com/hashicorp/go-tfe v0.3.18
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -18,7 +18,27 @@ for workspaces that the policy set is attached to.
 
 ## Example Usage
 
-Basic usage:
+Basic usage (VCS-based policy set):
+
+```hcl
+resource "tfe_policy_set" "test" {
+  name                   = "my-policy-set"
+  description            = "A brand new policy set"
+  organization           = "my-org-name"
+  workspace_external_ids = ["${tfe_workspace.test.external_id}"]
+
+  vcs_repo {
+    identifier         = "my-org-name/my-policy-set-repository"
+    branch             = "master"
+    ingress_submodules = false
+    oauth_token_id     = "${tfe_oauth_client.test.oauth_token_id}"
+  }
+
+  policies_path = "policies/my-policy-set"
+}
+```
+
+Using manually-specified policies:
 
 ```hcl
 resource "tfe_policy_set" "test" {
@@ -40,10 +60,35 @@ The following arguments are supported:
   all workspaces. Defaults to `false`. This value _must not_ be provided if
   `workspace_external_ids` are provided.
 * `organization` - (Required) Name of the organization.
-* `policy_ids` - (Required) A list of Sentinel policy IDs.
 * `workspace_external_ids` - (Optional) A list of workspace external IDs. If
   the policy set is `global`, this value _must not_ be provided.
+* `vcs_repo` - (Optional) The [VCS repository
+  settings](#vcs-repository-settings) for this policy set. Forces a new resource
+  if changed.
+* `policies_path` - (Optional) The sub-path within the attached VCS repository
+  to ingress when using `vcs_repo`. All files and directories outside of this
+  sub-path will be ignored. This option can only be supplied when `vcs_repo` is
+  present. Forces a new resource if changed.
+* `policy_ids` - (Optional) A list of Sentinel policy IDs.
 
+-> **Note:** When neither `vcs_repo` or `policy_ids` is not specified, the current default
+is to create an empty non-VCS policy set.
+
+### VCS Repository Settings
+
+The `vcs_repo` block takes the following arguments:
+
+* `identifier` - (Required) The identifier of the VCS repository in the format
+  `<namespace>/<repo>`. For example, on GitHub, this would be something like
+  `hashicorp/my-policy-set`.
+* `oauth_token_id` - (Required) The ID of the OAuth token assocaited with the
+  VCS repository to use. This can be fetched from the `oauth_token_id` attribute
+  of a `tfe_oauth_client` resource.
+* `branch` - (Optional) The branch of the VCS repo. If empty, the VCS provider's
+  default branch value will be used.
+* `ingress_submodules` - (Optional) Determines whether repository submodules
+  will be instantiated during the clone operation. Default: `false`.
+ 
 ## Attributes Reference
 
 * `id` - The ID of the policy set.

--- a/website/docs/r/policy_set.html.markdown
+++ b/website/docs/r/policy_set.html.markdown
@@ -25,6 +25,7 @@ resource "tfe_policy_set" "test" {
   name                   = "my-policy-set"
   description            = "A brand new policy set"
   organization           = "my-org-name"
+  policies_path          = "policies/my-policy-set"
   workspace_external_ids = ["${tfe_workspace.test.external_id}"]
 
   vcs_repo {
@@ -33,8 +34,6 @@ resource "tfe_policy_set" "test" {
     ingress_submodules = false
     oauth_token_id     = "${tfe_oauth_client.test.oauth_token_id}"
   }
-
-  policies_path = "policies/my-policy-set"
 }
 ```
 
@@ -60,35 +59,31 @@ The following arguments are supported:
   all workspaces. Defaults to `false`. This value _must not_ be provided if
   `workspace_external_ids` are provided.
 * `organization` - (Required) Name of the organization.
-* `workspace_external_ids` - (Optional) A list of workspace external IDs. If
   the policy set is `global`, this value _must not_ be provided.
-* `vcs_repo` - (Optional) The [VCS repository
-  settings](#vcs-repository-settings) for this policy set. Forces a new resource
-  if changed.
 * `policies_path` - (Optional) The sub-path within the attached VCS repository
   to ingress when using `vcs_repo`. All files and directories outside of this
   sub-path will be ignored. This option can only be supplied when `vcs_repo` is
   present. Forces a new resource if changed.
 * `policy_ids` - (Optional) A list of Sentinel policy IDs.
+* `vcs_repo` - (Optional) Settings for the policy sets VCS repository. Forces a
+  new resource if changed.
+* `workspace_external_ids` - (Optional) A list of workspace external IDs. If
 
--> **Note:** When neither `vcs_repo` or `policy_ids` is not specified, the current default
-is to create an empty non-VCS policy set.
+-> **Note:** When neither `vcs_repo` or `policy_ids` is not specified, the current
+default is to create an empty non-VCS policy set.
 
-### VCS Repository Settings
+The `vcs_repo` block supports:
 
-The `vcs_repo` block takes the following arguments:
+* `identifier` - (Required) A reference to your VCS repository in the format
+  `:org/:repo` where `:org` and `:repo` refer to the organization and repository
+  in your VCS provider.
+* `branch` - (Optional) The repository branch that Terraform will execute from.
+  Default to `master`.
+* `ingress_submodules` - (Optional) Whether submodules should be fetched when
+  cloning the VCS repository. Defaults to `false`.
+* `oauth_token_id` - (Required) Token ID of the VCS Connection (OAuth Conection Token)
+  to use.
 
-* `identifier` - (Required) The identifier of the VCS repository in the format
-  `<namespace>/<repo>`. For example, on GitHub, this would be something like
-  `hashicorp/my-policy-set`.
-* `oauth_token_id` - (Required) The ID of the OAuth token assocaited with the
-  VCS repository to use. This can be fetched from the `oauth_token_id` attribute
-  of a `tfe_oauth_client` resource.
-* `branch` - (Optional) The branch of the VCS repo. If empty, the VCS provider's
-  default branch value will be used.
-* `ingress_submodules` - (Optional) Determines whether repository submodules
-  will be instantiated during the clone operation. Default: `false`.
- 
 ## Attributes Reference
 
 * `id` - The ID of the policy set.


### PR DESCRIPTION
This adds the necessary changes to allow for VCS policy sets.

VCS-backed policy sets are defined by supplying the vcs_repo - and
optionally, policies_path, arguments to the tfe_policy_set resource.
This is in lieu of policy_ids.

Changing either vcs_repo or policies_path will result in a new
resource being forced.