### PR TITLE
Add Azure DevOps Server and Azure DevOps Services as valid OAuth client service providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.24
+	github.com/hashicorp/go-tfe v0.3.27
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.27
+	github.com/hashicorp/go-tfe v0.3.28
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.28
+	github.com/hashicorp/go-tfe v0.3.29
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -171,11 +171,15 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-slug v0.3.0 h1:L0c+AvH/J64iMNF4VqRaRku2DMTEuHioPVS7kMjWIU8=
 github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
+github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFMH0=
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
 github.com/hashicorp/go-tfe v0.3.24 h1:pqUiGQf3pZnDa7ZRtRtdHWMxt8Uhu1oWJA3m3JuJfIA=
 github.com/hashicorp/go-tfe v0.3.24/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
+github.com/hashicorp/go-tfe v0.3.27 h1:7XZ/ZoPyYoeuNXaWWW0mJOq016y0qb7I4Q0P/cagyu8=
+github.com/hashicorp/go-tfe v0.3.27/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82k
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
+github.com/hashicorp/go-service v0.0.0-20190301095854-3ec4b98dc730/go.mod h1:/EYLpLHGVoYkKzVx7vl1hJtt08ux/s3Ia3YmvmjKnGQ=
 github.com/hashicorp/go-slug v0.3.0 h1:L0c+AvH/J64iMNF4VqRaRku2DMTEuHioPVS7kMjWIU8=
 github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
@@ -180,6 +181,8 @@ github.com/hashicorp/go-tfe v0.3.24 h1:pqUiGQf3pZnDa7ZRtRtdHWMxt8Uhu1oWJA3m3JuJf
 github.com/hashicorp/go-tfe v0.3.24/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
 github.com/hashicorp/go-tfe v0.3.27 h1:7XZ/ZoPyYoeuNXaWWW0mJOq016y0qb7I4Q0P/cagyu8=
 github.com/hashicorp/go-tfe v0.3.27/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
+github.com/hashicorp/go-tfe v0.3.28 h1:We0B953itT1fcvPuGGKJVcL/Vq/PZ/MWDU/hFRmDhl0=
+github.com/hashicorp/go-tfe v0.3.28/go.mod h1:+bbL5jtTCyNbqhZhcKls8jmfqSdYx/l9J/1e84JuO/A=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/go.sum
+++ b/go.sum
@@ -169,7 +169,6 @@ github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82k
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-service v0.0.0-20190301095854-3ec4b98dc730/go.mod h1:/EYLpLHGVoYkKzVx7vl1hJtt08ux/s3Ia3YmvmjKnGQ=
 github.com/hashicorp/go-slug v0.3.0 h1:L0c+AvH/J64iMNF4VqRaRku2DMTEuHioPVS7kMjWIU8=
 github.com/hashicorp/go-slug v0.3.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
@@ -177,12 +176,8 @@ github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFMH0=
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
-github.com/hashicorp/go-tfe v0.3.24 h1:pqUiGQf3pZnDa7ZRtRtdHWMxt8Uhu1oWJA3m3JuJfIA=
-github.com/hashicorp/go-tfe v0.3.24/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
-github.com/hashicorp/go-tfe v0.3.27 h1:7XZ/ZoPyYoeuNXaWWW0mJOq016y0qb7I4Q0P/cagyu8=
-github.com/hashicorp/go-tfe v0.3.27/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
-github.com/hashicorp/go-tfe v0.3.28 h1:We0B953itT1fcvPuGGKJVcL/Vq/PZ/MWDU/hFRmDhl0=
-github.com/hashicorp/go-tfe v0.3.28/go.mod h1:+bbL5jtTCyNbqhZhcKls8jmfqSdYx/l9J/1e84JuO/A=
+github.com/hashicorp/go-tfe v0.3.29 h1:BnDYhGKOT/lHiYJg/n90+TByTBrp61ZFW7IAbR2AM7E=
+github.com/hashicorp/go-tfe v0.3.29/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -80,6 +80,11 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 	// Get the organization and provider.
 	organization := d.Get("organization").(string)
 	serviceProvider := tfe.ServiceProviderType(d.Get("service_provider").(string))
+	privateKey := d.Get("private_key").(string)
+
+	if serviceProvider == tfe.ServiceProviderAzureDevOpsServer && privateKey == "" {
+		return fmt.Errorf("PrivateKey is required for ServiceProvider %s", serviceProvider)
+	}
 
 	// Create a new options struct.
 	options := tfe.OAuthClientCreateOptions{
@@ -87,7 +92,7 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 		HTTPURL:         tfe.String(d.Get("http_url").(string)),
 		OAuthToken:      tfe.String(d.Get("oauth_token").(string)),
 		ServiceProvider: tfe.ServiceProvider(serviceProvider),
-		PrivateKey:      tfe.String(d.Get("private_key").(string)),
+		PrivateKey:      tfe.String(privateKey),
 	}
 
 	log.Printf("[DEBUG] Create an OAuth client for organization: %s", organization)

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -43,7 +43,7 @@ func resourceTFEOAuthClient() *schema.Resource {
 
 			"private_key": {
 				Type:     schema.TypeString,
-				ForceNew: true,
+				ForceNew: false,
 				Optional: true,
 			},
 
@@ -79,8 +79,8 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// Get the organization and provider.
 	organization := d.Get("organization").(string)
-	serviceProvider := tfe.ServiceProviderType(d.Get("service_provider").(string))
 	privateKey := d.Get("private_key").(string)
+	serviceProvider := tfe.ServiceProviderType(d.Get("service_provider").(string))
 
 	if serviceProvider == tfe.ServiceProviderAzureDevOpsServer && privateKey == "" {
 		return fmt.Errorf("PrivateKey is required for ServiceProvider %s", serviceProvider)
@@ -91,8 +91,8 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 		APIURL:          tfe.String(d.Get("api_url").(string)),
 		HTTPURL:         tfe.String(d.Get("http_url").(string)),
 		OAuthToken:      tfe.String(d.Get("oauth_token").(string)),
-		ServiceProvider: tfe.ServiceProvider(serviceProvider),
 		PrivateKey:      tfe.String(privateKey),
+		ServiceProvider: tfe.ServiceProvider(serviceProvider),
 	}
 
 	log.Printf("[DEBUG] Create an OAuth client for organization: %s", organization)

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -83,7 +83,7 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 	serviceProvider := tfe.ServiceProviderType(d.Get("service_provider").(string))
 
 	if serviceProvider == tfe.ServiceProviderAzureDevOpsServer && privateKey == "" {
-		return fmt.Errorf("PrivateKey is required for ServiceProvider %s", serviceProvider)
+		return fmt.Errorf("private_key is required for service_provider %s", serviceProvider)
 	}
 
 	// Create a new options struct.

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -41,6 +41,12 @@ func resourceTFEOAuthClient() *schema.Resource {
 				ForceNew:  true,
 			},
 
+			"private_key": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+
 			"service_provider": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -81,6 +87,7 @@ func resourceTFEOAuthClientCreate(d *schema.ResourceData, meta interface{}) erro
 		HTTPURL:         tfe.String(d.Get("http_url").(string)),
 		OAuthToken:      tfe.String(d.Get("oauth_token").(string)),
 		ServiceProvider: tfe.ServiceProvider(serviceProvider),
+		PrivateKey:      tfe.String(d.Get("private_key").(string)),
 	}
 
 	log.Printf("[DEBUG] Create an OAuth client for organization: %s", organization)

--- a/tfe/resource_tfe_oauth_client.go
+++ b/tfe/resource_tfe_oauth_client.go
@@ -47,6 +47,8 @@ func resourceTFEOAuthClient() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice(
 					[]string{
+						string(tfe.ServiceProviderAzureDevOpsServer),
+						string(tfe.ServiceProviderAzureDevOpsServices),
 						string(tfe.ServiceProviderBitbucket),
 						string(tfe.ServiceProviderGithub),
 						string(tfe.ServiceProviderGithubEE),

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -38,8 +38,8 @@ resource "tfe_oauth_client" "test" {
   api_url          = "https://ado.example.com"
   http_url         = "https://ado.example.com"
   oauth_token      = "my-vcs-provider-token"
-  service_provider = "ado_server"
   private_key      = "-----BEGIN RSA PRIVATE KEY-----\ncontent\n-----END RSA PRIVATE KEY-----"
+  service_provider = "ado_server"
 }
 ```
 
@@ -53,10 +53,10 @@ The following arguments are supported:
 * `http_url` - (Required) The homepage of your VCS provider (e.g.
   `https://github.com` or `https://ghe.example.com`).
 * `oauth_token` - (Required) The token string you were given by your VCS provider.
+* `private_key` - (Required for `ado_server`) The text of the private key associated with your Azure DevOps Server account
 * `service_provider` - (Required) The VCS provider being connected with. Valid
   options are `ado_server`, `ado_services`, `github`, `github_enterprise`, `gitlab_hosted`,
   `gitlab_community_edition`, or `gitlab_enterprise_edition`.
-* `private_key` - (Required for `ado_server`) The text of the private key associated with your Azure DevOps Server account
 
 ## Attributes Reference
 

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -41,6 +41,10 @@ The following arguments are supported:
 * `service_provider` - (Required) The VCS provider being connected with. Valid
   options are `ado_server`, `ado_services`, `github`, `github_enterprise`, `gitlab_hosted`,
   `gitlab_community_edition`, or `gitlab_enterprise_edition`.
+* `private_key` - (Optional) The text of the private key associated with your VCS provider user account
+
+-> **Note:** `private_key` is only available when the `service_provder` is set to Azure DevOps Server (`ado_server`)
+
 
 ## Attributes Reference
 

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -14,6 +14,8 @@ provider.
 -> **Note:** This resource does not currently support creation of Bitbucket
   Server OAuth clients.
 
+-> **Note:** This resource requires a private key when creating Azure DevOps Server OAuth clients.
+
 ## Example Usage
 
 Basic usage:
@@ -25,6 +27,19 @@ resource "tfe_oauth_client" "test" {
   http_url         = "https://github.com"
   oauth_token      = "my-vcs-provider-token"
   service_provider = "github"
+}
+```
+
+Azure DevOps Server usage:
+
+```hcl
+resource "tfe_oauth_client" "test" {
+  organization     = "my-org-name"
+  api_url          = "https://ado.example.com"
+  http_url         = "https://ado.example.com"
+  oauth_token      = "my-vcs-provider-token"
+  service_provider = "ado_server"
+  private_key      = "-----BEGIN RSA PRIVATE KEY-----\ncontent\n-----END RSA PRIVATE KEY-----"
 }
 ```
 
@@ -41,10 +56,7 @@ The following arguments are supported:
 * `service_provider` - (Required) The VCS provider being connected with. Valid
   options are `ado_server`, `ado_services`, `github`, `github_enterprise`, `gitlab_hosted`,
   `gitlab_community_edition`, or `gitlab_enterprise_edition`.
-* `private_key` - (Optional) The text of the private key associated with your VCS provider user account
-
--> **Note:** `private_key` is only available when the `service_provder` is set to Azure DevOps Server (`ado_server`)
-
+* `private_key` - (Required for `ado_server`) The text of the private key associated with your Azure DevOps Server account
 
 ## Attributes Reference
 

--- a/website/docs/r/oauth_client.html.markdown
+++ b/website/docs/r/oauth_client.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
   `https://github.com` or `https://ghe.example.com`).
 * `oauth_token` - (Required) The token string you were given by your VCS provider.
 * `service_provider` - (Required) The VCS provider being connected with. Valid
-  options are `github`, `github_enterprise`, `bitbucket_hosted`, `gitlab_hosted`,
+  options are `ado_server`, `ado_services`, `github`, `github_enterprise`, `gitlab_hosted`,
   `gitlab_community_edition`, or `gitlab_enterprise_edition`.
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

This adds support for using Azure DevOps Server and Azure DevOps Services as valid OAuth client service providers. 

~Depends on [this go-tfe PR being merged first](https://github.com/hashicorp/go-tfe/pull/89).~

~Also depends on [this go-tfe PR being merged](https://github.com/hashicorp/go-tfe/pull/94)~

## Testing
1. Build the provider
2. `cp $GOPATH/bin/terraform-provider-tfe ~/.terraform.d/plugins/`
3. Use this config:

```
# Configure the Terraform Enterprise Provider
provider "tfe" {
  hostname = "NGROK"
  token    = "ADMIN_TOKEN"
}
resource "tfe_oauth_client" "ado_server" {
  organization     = "hashicorp"
  api_url          = "https://ado.hashicorp.engineering"
  http_url         = "https://ado.hashicorp.engineering"
  oauth_token      = "my-vcs-provider-token"
  service_provider = "ado_server"
}

resource "tfe_oauth_client" "ado_server_with_private_key" {
  organization     = "hashicorp"
  api_url          = "https://ado.hashicorp.engineering"
  http_url         = "https://ado.hashicorp.engineering"
  oauth_token      = "my-vcs-provider-token"
  service_provider = "ado_server"
  private_key      = "-----BEGIN RSA PRIVATE KEY-----\ncontent\n-----END RSA PRIVATE KEY-----"
}

resource "tfe_oauth_client" "ado_services" {
  organization     = "hashicorp"
  api_url          = "https://dev.azure.com"
  http_url         = "https://dev.azure.com"
  oauth_token      = "my-vcs-provider-token"
  service_provider = "ado_services"
}
```

4. Margaritas?