### PR TITLE
Update test organization names to be consistent with go-tfe

### DIFF
--- a/tfe/data_source_ssh_key_test.go
+++ b/tfe/data_source_ssh_key_test.go
@@ -22,7 +22,7 @@ func TestAccTFESSHKeyDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_ssh_key.foobar", "name", fmt.Sprintf("ssh-key-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_ssh_key.foobar", "organization", fmt.Sprintf("terraform-test-%d", rInt)),
+						"data.tfe_ssh_key.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 					resource.TestCheckResourceAttrSet("data.tfe_ssh_key.foobar", "id"),
 				),
 			},
@@ -33,7 +33,7 @@ func TestAccTFESSHKeyDataSource_basic(t *testing.T) {
 func testAccTFESSHKeyDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test-%d"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/data_source_team_access_test.go
+++ b/tfe/data_source_team_access_test.go
@@ -33,7 +33,7 @@ func TestAccTFETeamAccessDataSource_basic(t *testing.T) {
 func testAccTFETeamAccessDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test-%d"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/data_source_team_test.go
+++ b/tfe/data_source_team_test.go
@@ -22,7 +22,7 @@ func TestAccTFETeamDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_team.foobar", "name", fmt.Sprintf("team-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_team.foobar", "organization", fmt.Sprintf("terraform-test-%d", rInt)),
+						"data.tfe_team.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 					resource.TestCheckResourceAttrSet("data.tfe_team.foobar", "id"),
 				),
 			},
@@ -33,7 +33,7 @@ func TestAccTFETeamDataSource_basic(t *testing.T) {
 func testAccTFETeamDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test-%d"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/data_source_workspace_ids_test.go
+++ b/tfe/data_source_workspace_ids_test.go
@@ -26,18 +26,18 @@ func TestAccTFEWorkspaceIDsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.1", fmt.Sprintf("workspace-bar-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar", "organization", fmt.Sprintf("terraform-test-%d", rInt)),
+						"data.tfe_workspace_ids.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "ids.%", "2"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar",
 						fmt.Sprintf("ids.workspace-foo-%d", rInt),
-						fmt.Sprintf("terraform-test-%d/workspace-foo-%d", rInt, rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar",
 						fmt.Sprintf("ids.workspace-bar-%d", rInt),
-						fmt.Sprintf("terraform-test-%d/workspace-bar-%d", rInt, rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-bar-%d", rInt, rInt),
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "external_ids.%", "2"),
@@ -68,23 +68,23 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "names.0", "*"),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace_ids.foobar", "organization", fmt.Sprintf("terraform-test-%d", rInt)),
+						"data.tfe_workspace_ids.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "ids.%", "3"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar",
 						fmt.Sprintf("ids.workspace-foo-%d", rInt),
-						fmt.Sprintf("terraform-test-%d/workspace-foo-%d", rInt, rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-foo-%d", rInt, rInt),
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar",
 						fmt.Sprintf("ids.workspace-bar-%d", rInt),
-						fmt.Sprintf("terraform-test-%d/workspace-bar-%d", rInt, rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-bar-%d", rInt, rInt),
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar",
 						fmt.Sprintf("ids.workspace-dummy-%d", rInt),
-						fmt.Sprintf("terraform-test-%d/workspace-dummy-%d", rInt, rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-dummy-%d", rInt, rInt),
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace_ids.foobar", "external_ids.%", "3"),
@@ -104,7 +104,7 @@ func TestAccTFEWorkspaceIDsDataSource_wildcard(t *testing.T) {
 func testAccTFEWorkspaceIDsDataSourceConfig_basic(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test-%d"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 
@@ -132,7 +132,7 @@ data "tfe_workspace_ids" "foobar" {
 func testAccTFEWorkspaceIDsDataSourceConfig_wildcard(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test-%d"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -22,12 +22,12 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar",
 						"id",
-						fmt.Sprintf("terraform-test-%d/workspace-test-%d", rInt, rInt),
+						fmt.Sprintf("tst-terraform-%d/workspace-test-%d", rInt, rInt),
 					),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "name", fmt.Sprintf("workspace-test-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"data.tfe_workspace.foobar", "organization", fmt.Sprintf("terraform-test-%d", rInt)),
+						"data.tfe_workspace.foobar", "organization", fmt.Sprintf("tst-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "auto_apply", "true"),
 					resource.TestCheckResourceAttr(
@@ -55,7 +55,7 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 func testAccTFEWorkspaceDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test-%d"
+  name  = "tst-terraform-%d"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_notification_configuration_test.go
+++ b/tfe/resource_tfe_notification_configuration_test.go
@@ -288,7 +288,7 @@ func testAccCheckTFENotificationConfigurationDestroy(s *terraform.State) error {
 
 const testAccTFENotificationConfiguration_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -306,7 +306,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_update = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -327,7 +327,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_slackWithToken = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -346,7 +346,7 @@ resource "tfe_notification_configuration" "foobar" {
 
 const testAccTFENotificationConfiguration_duplicateTriggers = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_oauth_client_test.go
+++ b/tfe/resource_tfe_oauth_client_test.go
@@ -110,7 +110,7 @@ func testAccCheckTFEOAuthClientDestroy(s *terraform.State) error {
 
 var testAccTFEOAuthClient_basic = fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_organization_test.go
+++ b/tfe/resource_tfe_organization_test.go
@@ -24,7 +24,7 @@ func TestAccTFEOrganization_basic(t *testing.T) {
 						"tfe_organization.foobar", org),
 					testAccCheckTFEOrganizationAttributes(org),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", "terraform-test"),
+						"tfe_organization.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
@@ -50,7 +50,7 @@ func TestAccTFEOrganization_update(t *testing.T) {
 						"tfe_organization.foobar", org),
 					testAccCheckTFEOrganizationAttributes(org),
 					resource.TestCheckResourceAttr(
-						"tfe_organization.foobar", "name", "terraform-test"),
+						"tfe_organization.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_organization.foobar", "email", "admin@company.com"),
 					resource.TestCheckResourceAttr(
@@ -133,7 +133,7 @@ func testAccCheckTFEOrganizationExists(
 func testAccCheckTFEOrganizationAttributes(
 	org *tfe.Organization) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if org.Name != "terraform-test" {
+		if org.Name != "tst-terraform" {
 			return fmt.Errorf("Bad name: %s", org.Name)
 		}
 
@@ -203,7 +203,7 @@ func testAccCheckTFEOrganizationDestroy(s *terraform.State) error {
 
 const testAccTFEOrganization_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }`
 

--- a/tfe/resource_tfe_organization_token_test.go
+++ b/tfe/resource_tfe_organization_token_test.go
@@ -24,7 +24,7 @@ func TestAccTFEOrganizationToken_basic(t *testing.T) {
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", "terraform-test"),
+						"tfe_organization_token.foobar", "organization", "tst-terraform"),
 				),
 			},
 		},
@@ -45,7 +45,7 @@ func TestAccTFEOrganizationToken_existsWithoutForce(t *testing.T) {
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", "terraform-test"),
+						"tfe_organization_token.foobar", "organization", "tst-terraform"),
 				),
 			},
 
@@ -71,7 +71,7 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.foobar", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.foobar", "organization", "terraform-test"),
+						"tfe_organization_token.foobar", "organization", "tst-terraform"),
 				),
 			},
 
@@ -81,7 +81,7 @@ func TestAccTFEOrganizationToken_existsWithForce(t *testing.T) {
 					testAccCheckTFEOrganizationTokenExists(
 						"tfe_organization_token.regenerated", token),
 					resource.TestCheckResourceAttr(
-						"tfe_organization_token.regenerated", "organization", "terraform-test"),
+						"tfe_organization_token.regenerated", "organization", "tst-terraform"),
 				),
 			},
 		},
@@ -160,7 +160,7 @@ func testAccCheckTFEOrganizationTokenDestroy(s *terraform.State) error {
 
 const testAccTFEOrganizationToken_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -170,7 +170,7 @@ resource "tfe_organization_token" "foobar" {
 
 const testAccTFEOrganizationToken_existsWithoutForce = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -184,7 +184,7 @@ resource "tfe_organization_token" "error" {
 
 const testAccTFEOrganizationToken_existsWithForce = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -23,7 +23,7 @@ func TestAccTFEPolicySet_basic(t *testing.T) {
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-test"),
+						"tfe_policy_set.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
@@ -50,7 +50,7 @@ func TestAccTFEPolicySet_update(t *testing.T) {
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-test"),
+						"tfe_policy_set.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
@@ -93,7 +93,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-test"),
+						"tfe_policy_set.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
@@ -108,7 +108,7 @@ func TestAccTFEPolicySet_updateEmpty(t *testing.T) {
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-test"),
+						"tfe_policy_set.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
@@ -273,7 +273,7 @@ func TestAccTFEPolicySet_vcs(t *testing.T) {
 					testAccCheckTFEPolicySetExists("tfe_policy_set.foobar", policySet),
 					testAccCheckTFEPolicySetAttributes(policySet),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set.foobar", "name", "terraform-test"),
+						"tfe_policy_set.foobar", "name", "tst-terraform"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set.foobar", "description", "Policy Set"),
 					resource.TestCheckResourceAttr(
@@ -341,7 +341,7 @@ func testAccCheckTFEPolicySetExists(n string, policySet *tfe.PolicySet) resource
 
 func testAccCheckTFEPolicySetAttributes(policySet *tfe.PolicySet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if policySet.Name != "terraform-test" {
+		if policySet.Name != "tst-terraform" {
 			return fmt.Errorf("Bad name: %s", policySet.Name)
 		}
 
@@ -384,7 +384,7 @@ func testAccCheckTFEPolicySetPopulated(policySet *tfe.PolicySet) resource.TestCh
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, "terraform-test", "workspace-foo")
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "workspace-foo")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -423,7 +423,7 @@ func testAccCheckTFEPolicySetGlobal(policySet *tfe.PolicySet) resource.TestCheck
 		}
 
 		workspaceID := policySet.Workspaces[0].ID
-		workspace, _ := tfeClient.Workspaces.Read(ctx, "terraform-test", "workspace-foo")
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "workspace-foo")
 		if workspace.ID != workspaceID {
 			return fmt.Errorf("Wrong member workspace: %v", workspace.Name)
 		}
@@ -455,7 +455,7 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 
 const testAccTFEPolicySet_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -466,7 +466,7 @@ resource "tfe_sentinel_policy" "foo" {
 }
 
 resource "tfe_policy_set" "foobar" {
-  name         = "terraform-test"
+  name         = "tst-terraform"
   description  = "Policy Set"
   organization = "${tfe_organization.foobar.id}"
   policy_ids   = ["${tfe_sentinel_policy.foo.id}"]
@@ -474,18 +474,18 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_empty = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
  resource "tfe_policy_set" "foobar" {
-  name         = "terraform-test"
+  name         = "tst-terraform"
   description  = "Policy Set"
   organization = "${tfe_organization.foobar.id}"
 }`
 
 const testAccTFEPolicySet_populated = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -509,7 +509,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_updatePopulated = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -544,7 +544,7 @@ resource "tfe_policy_set" "foobar" {
 
 const testAccTFEPolicySet_global = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -568,7 +568,7 @@ resource "tfe_policy_set" "foobar" {
 
 var testAccTFEPolicySet_vcs = fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -581,7 +581,7 @@ resource "tfe_oauth_client" "test" {
 }
 
 resource "tfe_policy_set" "foobar" {
-  name         = "terraform-test"
+  name         = "tst-terraform"
   description  = "Policy Set"
   organization = "${tfe_organization.foobar.id}"
   vcs_repo {

--- a/tfe/resource_tfe_sentinel_policy_test.go
+++ b/tfe/resource_tfe_sentinel_policy_test.go
@@ -95,7 +95,7 @@ func TestAccTFESentinelPolicy_import(t *testing.T) {
 			{
 				ResourceName:        "tfe_sentinel_policy.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "terraform-test/",
+				ImportStateIdPrefix: "tst-terraform/",
 				ImportStateVerify:   true,
 			},
 		},
@@ -184,7 +184,7 @@ func testAccCheckTFESentinelPolicyDestroy(s *terraform.State) error {
 
 const testAccTFESentinelPolicy_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -198,7 +198,7 @@ resource "tfe_sentinel_policy" "foobar" {
 
 const testAccTFESentinelPolicy_update = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_ssh_key_test.go
+++ b/tfe/resource_tfe_ssh_key_test.go
@@ -142,7 +142,7 @@ func testAccCheckTFESSHKeyDestroy(s *terraform.State) error {
 
 const testAccTFESSHKey_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -154,7 +154,7 @@ resource "tfe_ssh_key" "foobar" {
 
 const testAccTFESSHKey_update = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -44,7 +44,7 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 			{
 				ResourceName:        "tfe_team_access.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "terraform-test/workspace-test/",
+				ImportStateIdPrefix: "tst-terraform/workspace-test/",
 				ImportStateVerify:   true,
 			},
 		},
@@ -113,7 +113,7 @@ func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
 
 const testAccTFETeamAccess_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_member_test.go
+++ b/tfe/resource_tfe_team_member_test.go
@@ -210,7 +210,7 @@ func testAccCheckTFETeamMemberDestroy(s *terraform.State) error {
 
 const testAccTFETeamMember_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_members_test.go
+++ b/tfe/resource_tfe_team_members_test.go
@@ -200,7 +200,7 @@ func testAccCheckTFETeamMembersDestroy(s *terraform.State) error {
 
 var testAccTFETeamMembers_basic = fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -216,7 +216,7 @@ resource "tfe_team_members" "foobar" {
 
 var testAccTFETeamMembers_update = fmt.Sprintf(`
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_test.go
+++ b/tfe/resource_tfe_team_test.go
@@ -44,7 +44,7 @@ func TestAccTFETeam_import(t *testing.T) {
 			{
 				ResourceName:        "tfe_team.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "terraform-test/",
+				ImportStateIdPrefix: "tst-terraform/",
 				ImportStateVerify:   true,
 			},
 		},
@@ -113,7 +113,7 @@ func testAccCheckTFETeamDestroy(s *terraform.State) error {
 
 const testAccTFETeam_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_team_token_test.go
+++ b/tfe/resource_tfe_team_token_test.go
@@ -152,7 +152,7 @@ func testAccCheckTFETeamTokenDestroy(s *terraform.State) error {
 
 const testAccTFETeamToken_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -167,7 +167,7 @@ resource "tfe_team_token" "foobar" {
 
 const testAccTFETeamToken_existsWithoutForce = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -186,7 +186,7 @@ resource "tfe_team_token" "error" {
 
 const testAccTFETeamToken_existsWithForce = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -101,7 +101,7 @@ func TestAccTFEVariable_import(t *testing.T) {
 			{
 				ResourceName:        "tfe_variable.foobar",
 				ImportState:         true,
-				ImportStateIdPrefix: "terraform-test/workspace-test/",
+				ImportStateIdPrefix: "tst-terraform/workspace-test/",
 				ImportStateVerify:   true,
 			},
 		},
@@ -210,7 +210,7 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 
 const testAccTFEVariable_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -228,7 +228,7 @@ resource "tfe_variable" "foobar" {
 
 const testAccTFEVariable_update = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -463,7 +463,7 @@ func testAccCheckTFEWorkspaceRename() {
 
 	w, err := tfeClient.Workspaces.Update(
 		context.Background(),
-		"terraform-test",
+		"tst-terraform",
 		"workspace-test",
 		tfe.WorkspaceUpdateOptions{Name: tfe.String("renamed-out-of-band")},
 	)
@@ -547,7 +547,7 @@ func testAccCheckTFEWorkspaceDestroy(s *terraform.State) error {
 
 const testAccTFEWorkspace_basic = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -559,7 +559,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_basicFileTriggersOff = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -572,7 +572,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_monorepo = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -586,7 +586,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_renamed = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -598,7 +598,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_update = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -615,7 +615,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_sshKey = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 
@@ -634,7 +634,7 @@ resource "tfe_workspace" "foobar" {
 
 const testAccTFEWorkspace_noSSHKey = `
 resource "tfe_organization" "foobar" {
-  name  = "terraform-test"
+  name  = "tst-terraform"
   email = "admin@company.com"
 }
 


### PR DESCRIPTION
I've updated the test organization names to be consistent with the test organization names in go-tfe. 