### PR TITLE
BUGFIX: Use isValidString not nil check for private_key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.29
+	github.com/hashicorp/go-tfe v0.3.30
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFMH0=
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
-github.com/hashicorp/go-tfe v0.3.29 h1:BnDYhGKOT/lHiYJg/n90+TByTBrp61ZFW7IAbR2AM7E=
-github.com/hashicorp/go-tfe v0.3.29/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
+github.com/hashicorp/go-tfe v0.3.30 h1:rFgHipleCO2vvCumrRIe4Lcvit6uU/r+T3dGkkURmRE=
+github.com/hashicorp/go-tfe v0.3.30/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/vendor/github.com/hashicorp/go-tfe/oauth_client.go
+++ b/vendor/github.com/hashicorp/go-tfe/oauth_client.go
@@ -140,7 +140,7 @@ func (o OAuthClientCreateOptions) valid() error {
 	if o.ServiceProvider == nil {
 		return errors.New("service provider is required")
 	}
-	if o.PrivateKey != nil && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
+	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
 		return errors.New("Private Key can only be present with Azure DevOps Server service provider")
 	}
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.4.1
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.29
+# github.com/hashicorp/go-tfe v0.3.30
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid


### PR DESCRIPTION
Fixes issue with using oauth_client without private_key

This issue was fixed in upstream [go-tfe#96](https://github.com/hashicorp/go-tfe/pull/96)

https://github.com/hashicorp/go-tfe/commit/8b656f1e4c1b48738f180e9b171907f2dbc2c3c0#diff-46a4389c1970fe153de179797df5681d