### PR TITLE
Add organization membership resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.30
+	github.com/hashicorp/go-tfe v0.3.31
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFM
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
 github.com/hashicorp/go-tfe v0.3.30 h1:rFgHipleCO2vvCumrRIe4Lcvit6uU/r+T3dGkkURmRE=
 github.com/hashicorp/go-tfe v0.3.30/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
+github.com/hashicorp/go-tfe v0.3.31 h1:iVrOwuY2HxEv3IjK3pLpqBEVpfsVkhp2hU9UIFXd1Rs=
+github.com/hashicorp/go-tfe v0.3.31/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -73,6 +73,7 @@ func Provider() terraform.ResourceProvider {
 			"tfe_notification_configuration": resourceTFENotificationConfiguration(),
 			"tfe_oauth_client":               resourceTFEOAuthClient(),
 			"tfe_organization":               resourceTFEOrganization(),
+			"tfe_organization_membership":    resourceTFEOrganizationMembership(),
 			"tfe_organization_token":         resourceTFEOrganizationToken(),
 			"tfe_policy_set":                 resourceTFEPolicySet(),
 			"tfe_sentinel_policy":            resourceTFESentinelPolicy(),

--- a/tfe/resource_tfe_organization_membership.go
+++ b/tfe/resource_tfe_organization_membership.go
@@ -1,0 +1,97 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceTFEOrganizationMembership() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEOrganizationMembershipCreate,
+		Read:   resourceTFEOrganizationMembershipRead,
+		Delete: resourceTFEOrganizationMembershipDelete,
+
+		Schema: map[string]*schema.Schema{
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTFEOrganizationMembershipCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Get the email and organization.
+	email := d.Get("email").(string)
+	organization := d.Get("organization").(string)
+
+	// Create a new options struct.
+	options := tfe.OrganizationMembershipCreateOptions{
+		Email: tfe.String(email),
+	}
+
+	log.Printf("[DEBUG] Create membership %s for organization: %s", email, organization)
+	membership, err := tfeClient.OrganizationMemberships.Create(ctx, organization, options)
+	if err != nil {
+		return fmt.Errorf(
+			"Error creating membership %s for organization %s: %v", email, organization, err)
+	}
+
+	d.SetId(membership.ID)
+
+	return resourceTFEOrganizationMembershipRead(d, meta)
+}
+
+func resourceTFEOrganizationMembershipRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Create a new options struct.
+	options := tfe.OrganizationMembershipReadOptions{
+		Include: "user",
+	}
+
+	log.Printf("[DEBUG] Read configuration of membership: %s", d.Id())
+	membership, err := tfeClient.OrganizationMemberships.ReadWithOptions(ctx, d.Id(), options)
+
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] Membership %s does no longer exist", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading configuration of membership %s: %v", d.Id(), err)
+	}
+
+	// Update the config.
+	log.Printf("[INFO] User = %#v", membership.User)
+	d.Set("email", membership.User.Email)
+
+	return nil
+}
+
+func resourceTFEOrganizationMembershipDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Delete membership: %s", d.Id())
+	err := tfeClient.OrganizationMemberships.Delete(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error deleting membership %s: %v", d.Id(), err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_organization_membership_test.go
+++ b/tfe/resource_tfe_organization_membership_test.go
@@ -1,0 +1,107 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccTFEOrganizationMembership_basic(t *testing.T) {
+	mem := &tfe.OrganizationMembership{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEOrganizationMembershipDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEOrganizationMembership_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEOrganizationMembershipExists(
+						"tfe_organization_membership.foobar", mem),
+					testAccCheckTFEOrganizationMembershipAttributes(mem),
+					resource.TestCheckResourceAttr(
+						"tfe_organization_membership.foobar", "email", "example@hashicorp.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTFEOrganizationMembershipExists(
+	n string, membership *tfe.OrganizationMembership) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		options := tfe.OrganizationMembershipReadOptions{
+			Include: "user",
+		}
+
+		m, err := tfeClient.OrganizationMemberships.ReadWithOptions(ctx, rs.Primary.ID, options)
+		if err != nil {
+			return err
+		}
+
+		if m == nil {
+			return fmt.Errorf("Membership not found")
+		}
+
+		*membership = *m
+
+		return nil
+	}
+}
+
+func testAccCheckTFEOrganizationMembershipAttributes(
+	membership *tfe.OrganizationMembership) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if membership.User.Email != "example@hashicorp.com" {
+			return fmt.Errorf("Bad email: %s", membership.User.Email)
+		}
+		return nil
+	}
+}
+
+func testAccCheckTFEOrganizationMembershipDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_organization_membership" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.OrganizationMemberships.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Membership %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccTFEOrganizationMembership_basic = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_organization_membership" "foobar" {
+  email        = "example@hashicorp.com"
+  organization = "${tfe_organization.foobar.id}"
+}`

--- a/website/docs/r/organization_membership.html.markdown
+++ b/website/docs/r/organization_membership.html.markdown
@@ -1,0 +1,29 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_organization_membership"
+sidebar_current: "docs-resource-tfe-organization-membership-x"
+description: |-
+  Add or remove a user from an organization.
+---
+
+# tfe_organization_membership
+
+Add or remove a user from an organization.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization_membership" "test" {
+  organization  = "my-org-name"
+  email = "user@company.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) Name of the organization.
+* `email` - (Required) Email of the user to add.

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -49,6 +49,10 @@
                             <a href="/docs/providers/tfe/r/organization.html">tfe_organization</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-resource-tfe-organization-x") %>>
+                            <a href="/docs/providers/tfe/r/organization_membership.html">tfe_organization_membership</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-resource-tfe-organization-token") %>>
                             <a href="/docs/providers/tfe/r/organization_token.html">tfe_organization_token</a>
                         </li>


### PR DESCRIPTION
## TODO:
- [x] Resource documentation
- [x] Merge https://github.com/hashicorp/go-tfe/pull/98 and update `go.mod`

## Description
This PR adds the `organization-membership` resource. This resource will always destroy/create on updating since a user's email address can only be changed by that user alone. This creates some interesting scenarios when updating the email address in the configuration:

* **The email address is only changed in the TF configuration.** This will cause the invitation to be rescinded, or the user to be kicked out of the org and invited again with the new email address if the user has already accepted the invitation. It would be up to the person applying the configuration change to catch this and fix it.

* **The email address is changed by the user in the UI, but not changed in the TF configuration.** The next time the configuration is applied, the user will be kicked out of the organization and a new invitation will be created for the original email address. Similarly, it is up to the person applying the configuration change to catch and fix it.

* **The email address is changed in the configuration and the UI.** Terraform recognizes this scenario and realizes that the plan has no changes to apply.