### PR TITLE
Move tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+
+test_results_dir: &test_results_dir /tmp/test_results
+
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.11.13
+        environment:
+          TEST_RESULTS_DIR: *test_results_dir
+
+    working_directory: /go/src/github.com/terraform-providers/terraform-provider-tfe
+
+    steps:
+      - checkout
+      
+      - run: go get -v -t -d ./...
+      
+      - run:
+          name: Make test results directory
+          command: mkdir -p $TEST_RESULTS_DIR
+
+      # Split these out from the testacc make cmd
+      # because gotestsum requires only junit stdout
+      - run:
+          name: fmt check
+          command: make fmtcheck
+
+      - run:
+          name: Run tests
+          command: |
+              gotestsum --format short-verbose --junitfile \
+              $TEST_RESULTS_DIR/tests.xml -- `go list ./... |grep -v 'vendor'` -v -timeout 15m
+          no_output_timeout: 1800
+
+      - store_test_results:
+          path: *test_results_dir


### PR DESCRIPTION
This PR adds a CircleCI config so we can run acceptance tests in Circle.