### PR TITLE
Nested workspace variables and policy set parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-tfe
 
 require (
 	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e // indirect
-	github.com/hashicorp/go-tfe v0.3.30
+	github.com/hashicorp/go-tfe v0.4.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/hashicorp/go-tfe v0.3.16 h1:GS2yv580p0co4j3FBVaC6Zahd9mxdCGehhJ0qqzFM
 github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLVbCgyZPezM=
 github.com/hashicorp/go-tfe v0.3.30 h1:rFgHipleCO2vvCumrRIe4Lcvit6uU/r+T3dGkkURmRE=
 github.com/hashicorp/go-tfe v0.3.30/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
+github.com/hashicorp/go-tfe v0.4.0 h1:p5eh7MhrJ5ysAQaq4sbWg/eVJ94qtrqFJWqlYZZhgLE=
+github.com/hashicorp/go-tfe v0.4.0/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -75,6 +75,7 @@ func Provider() terraform.ResourceProvider {
 			"tfe_organization":               resourceTFEOrganization(),
 			"tfe_organization_token":         resourceTFEOrganizationToken(),
 			"tfe_policy_set":                 resourceTFEPolicySet(),
+			"tfe_policy_set_parameter":       resourceTFEPolicySetParameter(),
 			"tfe_sentinel_policy":            resourceTFESentinelPolicy(),
 			"tfe_ssh_key":                    resourceTFESSHKey(),
 			"tfe_team":                       resourceTFETeam(),

--- a/tfe/resource_tfe_policy_set_param.go
+++ b/tfe/resource_tfe_policy_set_param.go
@@ -1,0 +1,188 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceTFEPolicySetParameter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFEPolicySetParameterCreate,
+		Read:   resourceTFEPolicySetParameterRead,
+		Update: resourceTFEPolicySetParameterUpdate,
+		Delete: resourceTFEPolicySetParameterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceTFEPolicySetParameterImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"value": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Default:   "",
+				Sensitive: true,
+			},
+
+			"category": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{
+						string(tfe.CategoryPolicySet),
+					},
+					false,
+				),
+			},
+
+			"sensitive": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"policy_set_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTFEPolicySetParameterCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Get key and category.
+	key := d.Get("key").(string)
+	category := d.Get("category").(string)
+
+	ps := d.Get("policy_set_id").(string)
+	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	if err != nil {
+		return fmt.Errorf("Error retrieving policy set %s: %v", ps, err)
+	}
+
+	// Create a new options struct.
+	options := tfe.PolicySetParameterCreateOptions{
+		Key:       tfe.String(key),
+		Value:     tfe.String(d.Get("value").(string)),
+		Category:  tfe.Category(tfe.CategoryType(category)),
+		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
+	}
+
+	log.Printf("[DEBUG] Create %s variable: %s", category, key)
+	variable, err := tfeClient.PolicySetParameters.Create(ctx, policySet.ID, options)
+	if err != nil {
+		return fmt.Errorf("Error creating %s variable %s: %v", category, key, err)
+	}
+
+	d.SetId(variable.ID)
+
+	return resourceTFEPolicySetParameterRead(d, meta)
+}
+
+func resourceTFEPolicySetParameterRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	ps := d.Get("policy_set_id").(string)
+	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	if err != nil {
+		return fmt.Errorf("Error retrieving policy set %s: %v", ps, err)
+	}
+
+	log.Printf("[DEBUG] Read variable: %s", d.Id())
+	variable, err := tfeClient.PolicySetParameters.Read(ctx, policySet.ID, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] PolicySetParameter %s does no longer exist", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading variable %s: %v", d.Id(), err)
+	}
+
+	// Update config.
+	d.Set("key", variable.Key)
+	d.Set("category", string(variable.Category))
+	d.Set("sensitive", variable.Sensitive)
+
+	// Only set the value if its not sensitive, as otherwise it will be empty.
+	if !variable.Sensitive {
+		d.Set("value", variable.Value)
+	}
+
+	return nil
+}
+
+func resourceTFEPolicySetParameterUpdate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	ps := d.Get("policy_set_id").(string)
+	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	if err != nil {
+		return fmt.Errorf("Error retrieving policy set %s: %v", ps, err)
+	}
+
+	// Create a new options struct.
+	options := tfe.PolicySetParameterUpdateOptions{
+		Key:       tfe.String(d.Get("key").(string)),
+		Value:     tfe.String(d.Get("value").(string)),
+		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
+	}
+
+	log.Printf("[DEBUG] Update variable: %s", d.Id())
+	_, err = tfeClient.PolicySetParameters.Update(ctx, policySet.ID, d.Id(), options)
+	if err != nil {
+		return fmt.Errorf("Error updating variable %s: %v", d.Id(), err)
+	}
+
+	return resourceTFEPolicySetParameterRead(d, meta)
+}
+
+func resourceTFEPolicySetParameterDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	ps := d.Get("policy_set_id").(string)
+	policySet, err := tfeClient.PolicySets.Read(ctx, ps)
+	if err != nil {
+		return fmt.Errorf("Error retrieving policy set %s: %v", ps, err)
+	}
+
+	log.Printf("[DEBUG] Delete variable: %s", d.Id())
+	err = tfeClient.PolicySetParameters.Delete(ctx, policySet.ID, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error deleting variable%s: %v", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceTFEPolicySetParameterImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	s := strings.SplitN(d.Id(), "/", 2)
+	if len(s) != 2 {
+		return nil, fmt.Errorf(
+			"invalid variable import format: %s (expected <POLICY SET>/<VARIABLE ID>)",
+			d.Id(),
+		)
+	}
+
+	// Set the fields that are part of the import ID.
+	d.Set("policy_set_id", s[0])
+	d.SetId(s[1])
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/tfe/resource_tfe_policy_set_param.go
+++ b/tfe/resource_tfe_policy_set_param.go
@@ -67,13 +67,13 @@ func resourceTFEPolicySetParameterCreate(d *schema.ResourceData, meta interface{
 		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
 	}
 
-	log.Printf("[DEBUG] Create %s variable: %s", tfe.CategoryPolicySet, key)
-	variable, err := tfeClient.PolicySetParameters.Create(ctx, policySet.ID, options)
+	log.Printf("[DEBUG] Create %s parameter: %s", tfe.CategoryPolicySet, key)
+	parameter, err := tfeClient.PolicySetParameters.Create(ctx, policySet.ID, options)
 	if err != nil {
-		return fmt.Errorf("Error creating %s variable %s %v", tfe.CategoryPolicySet, key, err)
+		return fmt.Errorf("Error creating %s parameter %s %v", tfe.CategoryPolicySet, key, err)
 	}
 
-	d.SetId(variable.ID)
+	d.SetId(parameter.ID)
 
 	return resourceTFEPolicySetParameterRead(d, meta)
 }
@@ -87,24 +87,24 @@ func resourceTFEPolicySetParameterRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error retrieving policy set %s: %v", ps, err)
 	}
 
-	log.Printf("[DEBUG] Read variable: %s", d.Id())
-	variable, err := tfeClient.PolicySetParameters.Read(ctx, policySet.ID, d.Id())
+	log.Printf("[DEBUG] Read parameter: %s", d.Id())
+	parameter, err := tfeClient.PolicySetParameters.Read(ctx, policySet.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			log.Printf("[DEBUG] PolicySetParameter %s does no longer exist", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading variable %s: %v", d.Id(), err)
+		return fmt.Errorf("Error reading parameter %s: %v", d.Id(), err)
 	}
 
 	// Update config.
-	d.Set("key", variable.Key)
-	d.Set("sensitive", variable.Sensitive)
+	d.Set("key", parameter.Key)
+	d.Set("sensitive", parameter.Sensitive)
 
 	// Only set the value if its not sensitive, as otherwise it will be empty.
-	if !variable.Sensitive {
-		d.Set("value", variable.Value)
+	if !parameter.Sensitive {
+		d.Set("value", parameter.Value)
 	}
 
 	return nil
@@ -126,10 +126,10 @@ func resourceTFEPolicySetParameterUpdate(d *schema.ResourceData, meta interface{
 		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
 	}
 
-	log.Printf("[DEBUG] Update variable: %s", d.Id())
+	log.Printf("[DEBUG] Update parameter: %s", d.Id())
 	_, err = tfeClient.PolicySetParameters.Update(ctx, policySet.ID, d.Id(), options)
 	if err != nil {
-		return fmt.Errorf("Error updating variable %s: %v", d.Id(), err)
+		return fmt.Errorf("Error updating parameter %s: %v", d.Id(), err)
 	}
 
 	return resourceTFEPolicySetParameterRead(d, meta)
@@ -144,13 +144,13 @@ func resourceTFEPolicySetParameterDelete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error retrieving policy set %s: %v", ps, err)
 	}
 
-	log.Printf("[DEBUG] Delete variable: %s", d.Id())
+	log.Printf("[DEBUG] Delete parameter: %s", d.Id())
 	err = tfeClient.PolicySetParameters.Delete(ctx, policySet.ID, d.Id())
 	if err != nil {
 		if err == tfe.ErrResourceNotFound {
 			return nil
 		}
-		return fmt.Errorf("Error deleting variable%s: %v", d.Id(), err)
+		return fmt.Errorf("Error deleting parameter %s: %v", d.Id(), err)
 	}
 
 	return nil
@@ -160,7 +160,7 @@ func resourceTFEPolicySetParameterImporter(d *schema.ResourceData, meta interfac
 	s := strings.SplitN(d.Id(), "/", 2)
 	if len(s) != 2 {
 		return nil, fmt.Errorf(
-			"invalid variable import format: %s (expected <POLICY SET>/<VARIABLE ID>)",
+			"invalid parameter import format: %s (expected <POLICY SET ID>/<PARAMETER ID>)",
 			d.Id(),
 		)
 	}

--- a/tfe/resource_tfe_policy_set_param_test.go
+++ b/tfe/resource_tfe_policy_set_param_test.go
@@ -28,8 +28,6 @@ func TestAccTFEPolicySetParameter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set_parameter.foobar", "value", "value_test"),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set_parameter.foobar", "category", "policy-set"),
-					resource.TestCheckResourceAttr(
 						"tfe_policy_set_parameter.foobar", "sensitive", "false"),
 				),
 			},
@@ -56,8 +54,6 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set_parameter.foobar", "value", "value_test"),
 					resource.TestCheckResourceAttr(
-						"tfe_policy_set_parameter.foobar", "category", "policy-set"),
-					resource.TestCheckResourceAttr(
 						"tfe_policy_set_parameter.foobar", "sensitive", "false"),
 				),
 			},
@@ -72,8 +68,6 @@ func TestAccTFEPolicySetParameter_update(t *testing.T) {
 						"tfe_policy_set_parameter.foobar", "key", "key_updated"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set_parameter.foobar", "value", "value_updated"),
-					resource.TestCheckResourceAttr(
-						"tfe_policy_set_parameter.foobar", "category", "policy-set"),
 					resource.TestCheckResourceAttr(
 						"tfe_policy_set_parameter.foobar", "sensitive", "true"),
 				),
@@ -138,10 +132,6 @@ func testAccCheckTFEPolicySetParameterAttributes(
 			return fmt.Errorf("Bad value: %s", parameter.Value)
 		}
 
-		if parameter.Category != tfe.CategoryPolicySet {
-			return fmt.Errorf("Bad category: %s", parameter.Category)
-		}
-
 		if parameter.Sensitive != false {
 			return fmt.Errorf("Bad sensitive: %t", parameter.Sensitive)
 		}
@@ -159,10 +149,6 @@ func testAccCheckTFEPolicySetParameterAttributesUpdate(
 
 		if parameter.Value != "" {
 			return fmt.Errorf("Bad value: %s", parameter.Value)
-		}
-
-		if parameter.Category != tfe.CategoryPolicySet {
-			return fmt.Errorf("Bad category: %s", parameter.Category)
 		}
 
 		if parameter.Sensitive != true {
@@ -208,7 +194,6 @@ resource "tfe_policy_set" "foobar" {
 resource "tfe_policy_set_parameter" "foobar" {
   key          = "key_test"
   value        = "value_test"
-  category     = "policy-set"
   policy_set_id = "${tfe_policy_set.foobar.id}"
 }`
 
@@ -226,7 +211,6 @@ resource "tfe_policy_set" "foobar" {
 resource "tfe_policy_set_parameter" "foobar" {
   key          = "key_updated"
   value        = "value_updated"
-  category     = "policy-set"
   sensitive    = true
   policy_set_id = "${tfe_policy_set.foobar.id}"
 }`

--- a/tfe/resource_tfe_policy_set_param_test.go
+++ b/tfe/resource_tfe_policy_set_param_test.go
@@ -1,0 +1,232 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccTFEPolicySetParameter_basic(t *testing.T) {
+	parameter := &tfe.PolicySetParameter{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicySetParameter_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetParameterExists(
+						"tfe_policy_set_parameter.foobar", parameter),
+					testAccCheckTFEPolicySetParameterAttributes(parameter),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "key", "key_test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "value", "value_test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "category", "policy-set"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "sensitive", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetParameter_update(t *testing.T) {
+	parameter := &tfe.PolicySetParameter{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicySetParameter_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetParameterExists(
+						"tfe_policy_set_parameter.foobar", parameter),
+					testAccCheckTFEPolicySetParameterAttributes(parameter),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "key", "key_test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "value", "value_test"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "category", "policy-set"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "sensitive", "false"),
+				),
+			},
+
+			{
+				Config: testAccTFEPolicySetParameter_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEPolicySetParameterExists(
+						"tfe_policy_set_parameter.foobar", parameter),
+					testAccCheckTFEPolicySetParameterAttributesUpdate(parameter),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "key", "key_updated"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "value", "value_updated"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "category", "policy-set"),
+					resource.TestCheckResourceAttr(
+						"tfe_policy_set_parameter.foobar", "sensitive", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEPolicySetParameter_import(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetParameterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEPolicySetParameter_basic,
+			},
+
+			{
+				ResourceName:        "tfe_policy_set_parameter.foobar",
+				ImportState:         true,
+				ImportStateIdPrefix: "policy-set-test/",
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func testAccCheckTFEPolicySetParameterExists(
+	n string, parameter *tfe.PolicySetParameter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		v, err := tfeClient.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*parameter = *v
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetParameterAttributes(
+	parameter *tfe.PolicySetParameter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if parameter.Key != "key_test" {
+			return fmt.Errorf("Bad key: %s", parameter.Key)
+		}
+
+		if parameter.Value != "value_test" {
+			return fmt.Errorf("Bad value: %s", parameter.Value)
+		}
+
+		if parameter.Category != tfe.CategoryPolicySet {
+			return fmt.Errorf("Bad category: %s", parameter.Category)
+		}
+
+		if parameter.Sensitive != false {
+			return fmt.Errorf("Bad sensitive: %t", parameter.Sensitive)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetParameterAttributesUpdate(
+	parameter *tfe.PolicySetParameter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if parameter.Key != "key_updated" {
+			return fmt.Errorf("Bad key: %s", parameter.Key)
+		}
+
+		if parameter.Value != "" {
+			return fmt.Errorf("Bad value: %s", parameter.Value)
+		}
+
+		if parameter.Category != tfe.CategoryPolicySet {
+			return fmt.Errorf("Bad category: %s", parameter.Category)
+		}
+
+		if parameter.Sensitive != true {
+			return fmt.Errorf("Bad sensitive: %t", parameter.Sensitive)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFEPolicySetParameterDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_policy_set_parameter" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.PolicySetParameters.Read(ctx, rs.Primary.Attributes["policy_set_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("PolicySetParameter %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccTFEPolicySetParameter_basic = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_policy_set" "foobar" {
+  name         = "policy-set-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_policy_set_parameter" "foobar" {
+  key          = "key_test"
+  value        = "value_test"
+  category     = "policy-set"
+  policy_set_id = "${tfe_policy_set.foobar.id}"
+}`
+
+const testAccTFEPolicySetParameter_update = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_policy_set" "foobar" {
+  name         = "policy-set-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_policy_set_parameter" "foobar" {
+  key          = "key_updated"
+  value        = "value_updated"
+  category     = "policy-set"
+  sensitive    = true
+  policy_set_id = "${tfe_policy_set.foobar.id}"
+}`

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -122,7 +122,7 @@ func testAccCheckTFEVariableExists(
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		v, err := tfeClient.Variables.Read(ctx, rs.Primary.ID)
+		v, err := tfeClient.Variables.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func testAccCheckTFEVariableDestroy(s *terraform.State) error {
 			return fmt.Errorf("No instance ID is set")
 		}
 
-		_, err := tfeClient.Variables.Read(ctx, rs.Primary.ID)
+		_, err := tfeClient.Variables.Read(ctx, rs.Primary.Attributes["workspace_id"], rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Variable %s still exists", rs.Primary.ID)
 		}

--- a/vendor/github.com/hashicorp/go-tfe/README.md
+++ b/vendor/github.com/hashicorp/go-tfe/README.md
@@ -26,9 +26,10 @@ Currently the following endpoints are supported:
 - [x] [OAuth Clients](https://www.terraform.io/docs/enterprise/api/oauth-clients.html)
 - [x] [OAuth Tokens](https://www.terraform.io/docs/enterprise/api/oauth-tokens.html)
 - [x] [Organizations](https://www.terraform.io/docs/enterprise/api/organizations.html)
-- [ ] Organization Memberships
+- [x] [Organization Memberships](https://www.terraform.io/docs/cloud/api/organization-memberships.html)
 - [x] [Organization Tokens](https://www.terraform.io/docs/enterprise/api/organization-tokens.html)
 - [x] [Policies](https://www.terraform.io/docs/enterprise/api/policies.html)
+- [x] [Policy Set Parameters](https://www.terraform.io/docs/enterprise/api/policy-set-params.html)
 - [x] [Policy Sets](https://www.terraform.io/docs/enterprise/api/policy-sets.html)
 - [x] [Policy Checks](https://www.terraform.io/docs/enterprise/api/policy-checks.html)
 - [ ] [Registry Modules](https://www.terraform.io/docs/enterprise/api/modules.html)
@@ -39,7 +40,7 @@ Currently the following endpoints are supported:
 - [x] [Team Memberships](https://www.terraform.io/docs/enterprise/api/team-members.html)
 - [x] [Team Tokens](https://www.terraform.io/docs/enterprise/api/team-tokens.html)
 - [x] [Teams](https://www.terraform.io/docs/enterprise/api/teams.html)
-- [x] [Variables](https://www.terraform.io/docs/enterprise/api/variables.html)
+- [x] [Workspace Variables](https://www.terraform.io/docs/enterprise/api/workspace-variables.html)
 - [x] [Workspaces](https://www.terraform.io/docs/enterprise/api/workspaces.html)
 - [ ] [Admin](https://www.terraform.io/docs/enterprise/api/admin/index.html)
 

--- a/vendor/github.com/hashicorp/go-tfe/organization_membership.go
+++ b/vendor/github.com/hashicorp/go-tfe/organization_membership.go
@@ -1,0 +1,177 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ OrganizationMemberships = (*organizationMemberships)(nil)
+
+// OrganizationMemberships describes all the organization membership related methods that
+// the Terraform Enterprise API supports.
+//
+// TFE API docs:
+// https://www.terraform.io/docs/cloud/api/organization-memberships.html
+type OrganizationMemberships interface {
+	// List all the organization memberships of the given organization.
+	List(ctx context.Context, organization string, options OrganizationMembershipListOptions) (*OrganizationMembershipList, error)
+
+	// Create a new organization membership with the given options.
+	Create(ctx context.Context, organization string, options OrganizationMembershipCreateOptions) (*OrganizationMembership, error)
+
+	// Read an organization membership by ID
+	Read(ctx context.Context, organizationMembershipID string) (*OrganizationMembership, error)
+
+	// Read an organization membership by ID with options
+	ReadWithOptions(ctx context.Context, organizationMembershipID string, options OrganizationMembershipReadOptions) (*OrganizationMembership, error)
+
+	// Delete an organization membership by its ID.
+	Delete(ctx context.Context, organizationMembershipID string) error
+}
+
+// organizationMemberships implements OrganizationMemberships.
+type organizationMemberships struct {
+	client *Client
+}
+
+// OrganizationMembershipStatus represents an organization membership status.
+type OrganizationMembershipStatus string
+
+// List all available organization membership statuses.
+const (
+	OrganizationMembershipActive  = "active"
+	OrganizationMembershipInvited = "invited"
+)
+
+// OrganizationMembershipList represents a list of organization memberships.
+type OrganizationMembershipList struct {
+	*Pagination
+	Items []*OrganizationMembership
+}
+
+// OrganizationMembership represents a Terraform Enterprise organization membership.
+type OrganizationMembership struct {
+	ID     string                       `jsonapi:"primary,organization-memberships"`
+	Status OrganizationMembershipStatus `jsonapi:"attr,status"`
+
+	// Relations
+	Organization *Organization `jsonapi:"relation,organization"`
+	User         *User         `jsonapi:"relation,user"`
+	Teams        []*Team       `jsonapi:"relation,teams"`
+}
+
+// OrganizationMembershipListOptions represents the options for listing organization memberships.
+type OrganizationMembershipListOptions struct {
+	ListOptions
+
+	Include string `url:"include"`
+}
+
+// List all the organization memberships of the given organization.
+func (s *organizationMemberships) List(ctx context.Context, organization string, options OrganizationMembershipListOptions) (*OrganizationMembershipList, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ml := &OrganizationMembershipList{}
+	err = s.client.do(ctx, req, ml)
+	if err != nil {
+		return nil, err
+	}
+
+	return ml, nil
+}
+
+// OrganizationMembershipCreateOptions represents the options for creating an organization membership.
+type OrganizationMembershipCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,organization-memberships"`
+
+	// User's email address.
+	Email *string `jsonapi:"attr,email"`
+}
+
+func (o OrganizationMembershipCreateOptions) valid() error {
+	if o.Email == nil {
+		return errors.New("email is required")
+	}
+	return nil
+}
+
+// Create an organization membership with the given options.
+func (s *organizationMemberships) Create(ctx context.Context, organization string, options OrganizationMembershipCreateOptions) (*OrganizationMembership, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	options.ID = ""
+
+	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &OrganizationMembership{}
+	err = s.client.do(ctx, req, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// Read an organization membership by its ID.
+func (s *organizationMemberships) Read(ctx context.Context, organizationMembershipID string) (*OrganizationMembership, error) {
+	return s.ReadWithOptions(ctx, organizationMembershipID, OrganizationMembershipReadOptions{})
+}
+
+// OrganizationMembershipReadOptions represents the options for reading organization memberships.
+type OrganizationMembershipReadOptions struct {
+	Include string `url:"include"`
+}
+
+// Read an organization membership by ID with options
+func (s *organizationMemberships) ReadWithOptions(ctx context.Context, organizationMembershipID string, options OrganizationMembershipReadOptions) (*OrganizationMembership, error) {
+	if !validStringID(&organizationMembershipID) {
+		return nil, errors.New("invalid value for membership")
+	}
+
+	u := fmt.Sprintf("organization-memberships/%s", url.QueryEscape(organizationMembershipID))
+	req, err := s.client.newRequest("GET", u, &options)
+
+	mem := &OrganizationMembership{}
+	err = s.client.do(ctx, req, mem)
+	if err != nil {
+		return nil, err
+	}
+
+	return mem, nil
+}
+
+// Delete an organization membership by its ID.
+func (s *organizationMemberships) Delete(ctx context.Context, organizationMembershipID string) error {
+	if !validStringID(&organizationMembershipID) {
+		return errors.New("invalid value for membership")
+	}
+
+	u := fmt.Sprintf("organization-memberships/%s", url.QueryEscape(organizationMembershipID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/vendor/github.com/hashicorp/go-tfe/policy_set_parameter.go
+++ b/vendor/github.com/hashicorp/go-tfe/policy_set_parameter.go
@@ -1,0 +1,230 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ PolicySetParameters = (*policySetParameters)(nil)
+
+// PolicySetParameters describes all the parameter related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/enterprise/api/policy-set-params.html
+type PolicySetParameters interface {
+	// List all the parameters associated with the given policy-set.
+	List(ctx context.Context, policySetID string, options PolicySetParameterListOptions) (*PolicySetParameterList, error)
+
+	// Create is used to create a new parameter.
+	Create(ctx context.Context, policySetID string, options PolicySetParameterCreateOptions) (*PolicySetParameter, error)
+
+	// Read a parameter by its ID.
+	Read(ctx context.Context, policySetID string, parameterID string) (*PolicySetParameter, error)
+
+	// Update values of an existing parameter.
+	Update(ctx context.Context, policySetID string, parameterID string, options PolicySetParameterUpdateOptions) (*PolicySetParameter, error)
+
+	// Delete a parameter by its ID.
+	Delete(ctx context.Context, policySetID string, parameterID string) error
+}
+
+// policySetParameters implements Parameters.
+type policySetParameters struct {
+	client *Client
+}
+
+// PolicySetParameterList represents a list of parameters.
+type PolicySetParameterList struct {
+	*Pagination
+	Items []*PolicySetParameter
+}
+
+// PolicySetParameter represents a Policy Set parameter
+type PolicySetParameter struct {
+	ID        string       `jsonapi:"primary,vars"`
+	Key       string       `jsonapi:"attr,key"`
+	Value     string       `jsonapi:"attr,value"`
+	Category  CategoryType `jsonapi:"attr,category"`
+	Sensitive bool         `jsonapi:"attr,sensitive"`
+
+	// Relations
+	PolicySet *PolicySet `jsonapi:"relation,configurable"`
+}
+
+// PolicySetParameterListOptions represents the options for listing parameters.
+type PolicySetParameterListOptions struct {
+	ListOptions
+}
+
+func (o PolicySetParameterListOptions) valid() error {
+	return nil
+}
+
+// List all the parameters associated with the given policy-set.
+func (s *policySetParameters) List(ctx context.Context, policySetID string, options PolicySetParameterListOptions) (*PolicySetParameterList, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/parameters", policySetID)
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	vl := &PolicySetParameterList{}
+	err = s.client.do(ctx, req, vl)
+	if err != nil {
+		return nil, err
+	}
+
+	return vl, nil
+}
+
+// PolicySetParameterCreateOptions represents the options for creating a new parameter.
+type PolicySetParameterCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,vars"`
+
+	// The name of the parameter.
+	Key *string `jsonapi:"attr,key"`
+
+	// The value of the parameter.
+	Value *string `jsonapi:"attr,value,omitempty"`
+
+	// The Category of the parameter, should always be "policy-set"
+	Category *CategoryType `jsonapi:"attr,category"`
+
+	// Whether the value is sensitive.
+	Sensitive *bool `jsonapi:"attr,sensitive,omitempty"`
+}
+
+func (o PolicySetParameterCreateOptions) valid() error {
+	if !validString(o.Key) {
+		return errors.New("key is required")
+	}
+	if o.Category == nil {
+		return errors.New("category is required")
+	}
+	if *o.Category != CategoryPolicySet {
+		return errors.New("category must be policy-set")
+	}
+	return nil
+}
+
+// Create is used to create a new parameter.
+func (s *policySetParameters) Create(ctx context.Context, policySetID string, options PolicySetParameterCreateOptions) (*PolicySetParameter, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("policy-sets/%s/parameters", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &PolicySetParameter{}
+	err = s.client.do(ctx, req, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Read a parameter by its ID.
+func (s *policySetParameters) Read(ctx context.Context, policySetID string, parameterID string) (*PolicySetParameter, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+	if !validStringID(&parameterID) {
+		return nil, errors.New("invalid value for parameter ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &PolicySetParameter{}
+	err = s.client.do(ctx, req, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, err
+}
+
+// PolicySetParameterUpdateOptions represents the options for updating a parameter.
+type PolicySetParameterUpdateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,vars"`
+
+	// The name of the parameter.
+	Key *string `jsonapi:"attr,key,omitempty"`
+
+	// The value of the parameter.
+	Value *string `jsonapi:"attr,value,omitempty"`
+
+	// Whether the value is sensitive.
+	Sensitive *bool `jsonapi:"attr,sensitive,omitempty"`
+}
+
+// Update values of an existing parameter.
+func (s *policySetParameters) Update(ctx context.Context, policySetID string, parameterID string, options PolicySetParameterUpdateOptions) (*PolicySetParameter, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+	if !validStringID(&parameterID) {
+		return nil, errors.New("invalid value for parameter ID")
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = parameterID
+
+	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &PolicySetParameter{}
+	err = s.client.do(ctx, req, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Delete a parameter by its ID.
+func (s *policySetParameters) Delete(ctx context.Context, policySetID string, parameterID string) error {
+	if !validStringID(&policySetID) {
+		return errors.New("invalid value for policy set ID")
+	}
+	if !validStringID(&parameterID) {
+		return errors.New("invalid value for parameter ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -113,11 +113,13 @@ type Client struct {
 	OAuthClients               OAuthClients
 	OAuthTokens                OAuthTokens
 	Organizations              Organizations
+	OrganizationMemberships    OrganizationMemberships
 	OrganizationTokens         OrganizationTokens
 	Plans                      Plans
 	PlanExports                PlanExports
 	Policies                   Policies
 	PolicyChecks               PolicyChecks
+	PolicySetParameters        PolicySetParameters
 	PolicySets                 PolicySets
 	Runs                       Runs
 	SSHKeys                    SSHKeys
@@ -204,11 +206,13 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.OAuthClients = &oAuthClients{client: client}
 	client.OAuthTokens = &oAuthTokens{client: client}
 	client.Organizations = &organizations{client: client}
+	client.OrganizationMemberships = &organizationMemberships{client: client}
 	client.OrganizationTokens = &organizationTokens{client: client}
 	client.Plans = &plans{client: client}
 	client.PlanExports = &planExports{client: client}
 	client.Policies = &policies{client: client}
 	client.PolicyChecks = &policyChecks{client: client}
+	client.PolicySetParameters = &policySetParameters{client: client}
 	client.PolicySets = &policySets{client: client}
 	client.Runs = &runs{client: client}
 	client.SSHKeys = &sshKeys{client: client}

--- a/vendor/github.com/hashicorp/go-tfe/variable.go
+++ b/vendor/github.com/hashicorp/go-tfe/variable.go
@@ -16,19 +16,19 @@ var _ Variables = (*variables)(nil)
 // TFE API docs: https://www.terraform.io/docs/enterprise/api/variables.html
 type Variables interface {
 	// List all the variables associated with the given workspace.
-	List(ctx context.Context, options VariableListOptions) (*VariableList, error)
+	List(ctx context.Context, workspaceID string, options VariableListOptions) (*VariableList, error)
 
 	// Create is used to create a new variable.
-	Create(ctx context.Context, options VariableCreateOptions) (*Variable, error)
+	Create(ctx context.Context, workspaceID string, options VariableCreateOptions) (*Variable, error)
 
 	// Read a variable by its ID.
-	Read(ctx context.Context, variableID string) (*Variable, error)
+	Read(ctx context.Context, workspaceID string, variableID string) (*Variable, error)
 
 	// Update values of an existing variable.
-	Update(ctx context.Context, variableID string, options VariableUpdateOptions) (*Variable, error)
+	Update(ctx context.Context, workspaceID string, variableID string, options VariableUpdateOptions) (*Variable, error)
 
 	// Delete a variable by its ID.
-	Delete(ctx context.Context, variableID string) error
+	Delete(ctx context.Context, workspaceID string, variableID string) error
 }
 
 // variables implements Variables.
@@ -42,6 +42,7 @@ type CategoryType string
 //List all available categories.
 const (
 	CategoryEnv       CategoryType = "env"
+	CategoryPolicySet CategoryType = "policy-set"
 	CategoryTerraform CategoryType = "terraform"
 )
 
@@ -56,38 +57,28 @@ type Variable struct {
 	ID        string       `jsonapi:"primary,vars"`
 	Key       string       `jsonapi:"attr,key"`
 	Value     string       `jsonapi:"attr,value"`
+	Description string     `jsonapi:"attr,description"`
 	Category  CategoryType `jsonapi:"attr,category"`
 	HCL       bool         `jsonapi:"attr,hcl"`
 	Sensitive bool         `jsonapi:"attr,sensitive"`
 
 	// Relations
-	Workspace *Workspace `jsonapi:"relation,workspace"`
+	Workspace *Workspace `jsonapi:"relation,configurable"`
 }
 
 // VariableListOptions represents the options for listing variables.
 type VariableListOptions struct {
 	ListOptions
-	Organization *string `url:"filter[organization][name]"`
-	Workspace    *string `url:"filter[workspace][name]"`
-}
-
-func (o VariableListOptions) valid() error {
-	if !validString(o.Organization) {
-		return errors.New("organization is required")
-	}
-	if !validString(o.Workspace) {
-		return errors.New("workspace is required")
-	}
-	return nil
 }
 
 // List all the variables associated with the given workspace.
-func (s *variables) List(ctx context.Context, options VariableListOptions) (*VariableList, error) {
-	if err := options.valid(); err != nil {
-		return nil, err
+func (s *variables) List(ctx context.Context, workspaceID string, options VariableListOptions) (*VariableList, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
 	}
 
-	req, err := s.client.newRequest("GET", "vars", &options)
+	u := fmt.Sprintf("workspaces/%s/vars", workspaceID)
+	req, err := s.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +103,9 @@ type VariableCreateOptions struct {
 	// The value of the variable.
 	Value *string `jsonapi:"attr,value,omitempty"`
 
+	// The description of the variable.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
 	// Whether this is a Terraform or environment variable.
 	Category *CategoryType `jsonapi:"attr,category"`
 
@@ -120,9 +114,6 @@ type VariableCreateOptions struct {
 
 	// Whether the value is sensitive.
 	Sensitive *bool `jsonapi:"attr,sensitive,omitempty"`
-
-	// The workspace that owns the variable.
-	Workspace *Workspace `jsonapi:"relation,workspace"`
 }
 
 func (o VariableCreateOptions) valid() error {
@@ -132,14 +123,14 @@ func (o VariableCreateOptions) valid() error {
 	if o.Category == nil {
 		return errors.New("category is required")
 	}
-	if o.Workspace == nil {
-		return errors.New("workspace is required")
-	}
 	return nil
 }
 
 // Create is used to create a new variable.
-func (s *variables) Create(ctx context.Context, options VariableCreateOptions) (*Variable, error) {
+func (s *variables) Create(ctx context.Context, workspaceID string, options VariableCreateOptions) (*Variable, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
@@ -147,7 +138,8 @@ func (s *variables) Create(ctx context.Context, options VariableCreateOptions) (
 	// Make sure we don't send a user provided ID.
 	options.ID = ""
 
-	req, err := s.client.newRequest("POST", "vars", &options)
+	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
@@ -162,12 +154,15 @@ func (s *variables) Create(ctx context.Context, options VariableCreateOptions) (
 }
 
 // Read a variable by its ID.
-func (s *variables) Read(ctx context.Context, variableID string) (*Variable, error) {
+func (s *variables) Read(ctx context.Context, workspaceID string, variableID string) (*Variable, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
 	if !validStringID(&variableID) {
 		return nil, errors.New("invalid value for variable ID")
 	}
 
-	u := fmt.Sprintf("vars/%s", url.QueryEscape(variableID))
+	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -193,6 +188,9 @@ type VariableUpdateOptions struct {
 	// The value of the variable.
 	Value *string `jsonapi:"attr,value,omitempty"`
 
+	// The description of the variable.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
 	// Whether to evaluate the value of the variable as a string of HCL code.
 	HCL *bool `jsonapi:"attr,hcl,omitempty"`
 
@@ -201,7 +199,10 @@ type VariableUpdateOptions struct {
 }
 
 // Update values of an existing variable.
-func (s *variables) Update(ctx context.Context, variableID string, options VariableUpdateOptions) (*Variable, error) {
+func (s *variables) Update(ctx context.Context, workspaceID string, variableID string, options VariableUpdateOptions) (*Variable, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
 	if !validStringID(&variableID) {
 		return nil, errors.New("invalid value for variable ID")
 	}
@@ -209,7 +210,7 @@ func (s *variables) Update(ctx context.Context, variableID string, options Varia
 	// Make sure we don't send a user provided ID.
 	options.ID = variableID
 
-	u := fmt.Sprintf("vars/%s", url.QueryEscape(variableID))
+	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
 	req, err := s.client.newRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -225,12 +226,15 @@ func (s *variables) Update(ctx context.Context, variableID string, options Varia
 }
 
 // Delete a variable by its ID.
-func (s *variables) Delete(ctx context.Context, variableID string) error {
+func (s *variables) Delete(ctx context.Context, workspaceID string, variableID string) error {
+	if !validStringID(&workspaceID) {
+		return errors.New("invalid value for workspace ID")
+	}
 	if !validStringID(&variableID) {
 		return errors.New("invalid value for variable ID")
 	}
 
-	u := fmt.Sprintf("vars/%s", url.QueryEscape(variableID))
+	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
 	req, err := s.client.newRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.4.1
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.3.30
+# github.com/hashicorp/go-tfe v0.4.0
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid

--- a/website/docs/r/policy_set_parameters.html.markdown
+++ b/website/docs/r/policy_set_parameters.html.markdown
@@ -1,0 +1,58 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_policy_set_parameter"
+sidebar_current: "docs-resource-tfe-policy-set-parameter"
+description: |-
+  Manages policy set parameters.
+---
+
+# tfe_policy_set_parameter
+
+Creates, updates and destroys policy set parameters.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization" "test" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_policy_set" "test" {
+  name         = "my-policy-set-name"
+  organization = "${tfe_organization.test.id}"
+}
+
+resource "tfe_policy_set_parameter" "test" {
+  key          = "my_key_name"
+  value        = "my_value_name"
+  policy_set_id = "${tfe_policy_set.test.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `key` - (Required) Name of the parameter.
+* `value` - (Required) Value of the parameter.
+* `sensitive` - (Optional) Whether the value is sensitive. If true then the
+  parameter is written once and not visible thereafter. Defaults to `false`.
+* `policy_set_id` - (Required) The ID of the policy set that owns the parameter.
+
+## Attributes Reference
+
+* `id` - The ID of the parameter.
+
+## Import
+
+Parameters can be imported; use
+`<POLICY SET ID>/<PARAMETER ID>` as the import ID. For
+example:
+
+```shell
+terraform import tfe_policy_set_parameter.test polset-wAs3zYmWAhYK7peR/var-5rTwnSaRPogw6apb
+```
+


### PR DESCRIPTION
This PR adds support for policy set parameters, but also updates the workspace variable resource to utilize the "nested" routes that are now preferred.

The change made in workspace variables is **not** a breaking change and is backwards compatible with the existing setup.