### PR TITLE
Add description to workspace variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,11 @@ $ TESTARGS="-run TestAccTFENotificationConfiguration" envchain YOUR_NAMESPACE_HE
 ```sh
 $ TESTARGS="-run TestAccTFENotificationConfiguration" make testacc
 ```   
+
+### 4. Referencing a local version of `go-tfe`
+
+You may want to run tests against a local version of `go-tfe`. Add the following line to `go.mod` above the require statement, using your local path to `go-tfe`.
+
+```
+replace github.com/hashicorp/go-tfe => /Users/stacyharrison/Desktop/code/go-tfe
+```

--- a/README.md
+++ b/README.md
@@ -138,5 +138,5 @@ $ TESTARGS="-run TestAccTFENotificationConfiguration" make testacc
 You may want to run tests against a local version of `go-tfe`. Add the following line to `go.mod` above the require statement, using your local path to `go-tfe`.
 
 ```
-replace github.com/hashicorp/go-tfe => /Users/stacyharrison/Desktop/code/go-tfe
+replace github.com/hashicorp/go-tfe => /path-to-local-repo/go-tfe
 ```

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -174,10 +174,11 @@ func resourceTFEVariableUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	// Create a new options struct.
 	options := tfe.VariableUpdateOptions{
-		Key:       tfe.String(d.Get("key").(string)),
-		Value:     tfe.String(d.Get("value").(string)),
-		HCL:       tfe.Bool(d.Get("hcl").(bool)),
-		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
+		Key:         tfe.String(d.Get("key").(string)),
+		Value:       tfe.String(d.Get("value").(string)),
+		HCL:         tfe.Bool(d.Get("hcl").(bool)),
+		Sensitive:   tfe.Bool(d.Get("sensitive").(bool)),
+		Description: tfe.String(d.Get("description").(string)),
 	}
 
 	log.Printf("[DEBUG] Update variable: %s", d.Id())

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -95,11 +95,11 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Create a new options struct.
 	options := tfe.VariableCreateOptions{
-		Key:       tfe.String(key),
-		Value:     tfe.String(d.Get("value").(string)),
-		Category:  tfe.Category(tfe.CategoryType(category)),
-		HCL:       tfe.Bool(d.Get("hcl").(bool)),
-		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
+		Key:         tfe.String(key),
+		Value:       tfe.String(d.Get("value").(string)),
+		Category:    tfe.Category(tfe.CategoryType(category)),
+		HCL:         tfe.Bool(d.Get("hcl").(bool)),
+		Sensitive:   tfe.Bool(d.Get("sensitive").(bool)),
 		Description: tfe.String(d.Get("description").(string)),
 	}
 

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -46,6 +46,12 @@ func resourceTFEVariable() *schema.Resource {
 				),
 			},
 
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
 			"hcl": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -94,6 +100,7 @@ func resourceTFEVariableCreate(d *schema.ResourceData, meta interface{}) error {
 		Category:  tfe.Category(tfe.CategoryType(category)),
 		HCL:       tfe.Bool(d.Get("hcl").(bool)),
 		Sensitive: tfe.Bool(d.Get("sensitive").(bool)),
+		Description: tfe.String(d.Get("description").(string)),
 	}
 
 	log.Printf("[DEBUG] Create %s variable: %s", category, key)
@@ -137,6 +144,7 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 	// Update config.
 	d.Set("key", variable.Key)
 	d.Set("category", string(variable.Category))
+	d.Set("description", string(variable.Description))
 	d.Set("hcl", variable.HCL)
 	d.Set("sensitive", variable.Sensitive)
 

--- a/tfe/resource_tfe_variable_test.go
+++ b/tfe/resource_tfe_variable_test.go
@@ -28,6 +28,8 @@ func TestAccTFEVariable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "value", "value_test"),
 					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "description", "some description"),
+					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "category", "env"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "hcl", "false"),
@@ -58,6 +60,8 @@ func TestAccTFEVariable_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "value", "value_test"),
 					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "description", "some description"),
+					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "category", "env"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "hcl", "false"),
@@ -76,6 +80,8 @@ func TestAccTFEVariable_update(t *testing.T) {
 						"tfe_variable.foobar", "key", "key_updated"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "value", "value_updated"),
+					resource.TestCheckResourceAttr(
+						"tfe_variable.foobar", "description", "another description"),
 					resource.TestCheckResourceAttr(
 						"tfe_variable.foobar", "category", "terraform"),
 					resource.TestCheckResourceAttr(
@@ -155,6 +161,10 @@ func testAccCheckTFEVariableAttributes(
 			return fmt.Errorf("Bad value: %s", variable.Value)
 		}
 
+		if variable.Description != "some description" {
+			return fmt.Errorf("Bad description: %s", variable.Description)
+		}
+
 		if variable.Category != tfe.CategoryEnv {
 			return fmt.Errorf("Bad category: %s", variable.Category)
 		}
@@ -180,6 +190,10 @@ func testAccCheckTFEVariableAttributesUpdate(
 
 		if variable.Value != "" {
 			return fmt.Errorf("Bad value: %s", variable.Value)
+		}
+
+		if variable.Description != "another description" {
+			return fmt.Errorf("Bad description: %s", variable.Description)
 		}
 
 		if variable.Category != tfe.CategoryTerraform {
@@ -233,6 +247,7 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_variable" "foobar" {
   key          = "key_test"
   value        = "value_test"
+  description  = "some description"
   category     = "env"
   workspace_id = "${tfe_workspace.foobar.id}"
 }`
@@ -251,6 +266,7 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_variable" "foobar" {
   key          = "key_updated"
   value        = "value_updated"
+  description  = "another description"
   category     = "terraform"
   hcl          = true
   sensitive    = true

--- a/website/docs/r/variable.html.markdown
+++ b/website/docs/r/variable.html.markdown
@@ -30,6 +30,7 @@ resource "tfe_variable" "test" {
   value        = "my_value_name"
   category     = "terraform"
   workspace_id = "${tfe_workspace.test.id}"
+  description  = "a useful description"
 }
 ```
 
@@ -41,6 +42,7 @@ The following arguments are supported:
 * `value` - (Required) Value of the variable.
 * `category` - (Required) Whether this is a Terraform or environment variable.
   Valid values are `terraform` or `env`.
+* `description` - (Optional) Description of the variable.
 * `hcl` - (Optional) Whether to evaluate the value of the variable as a string
   of HCL code. Has no effect for environment variables. Defaults to `false`.
 * `sensitive` - (Optional) Whether the value is sensitive. If true then the


### PR DESCRIPTION
# Description

Workspace variables (`terraform` and `env`) now support descriptions. These descriptions are complete separate from descriptions defined in an ingressed config, but appear in the Terraform Cloud UI where Variables are configured.

# Testing plan

Create a variable with a description like:
```
resource "tfe_variable" "pet_name_length" {
    key = "pet_name_length"
    value = "5"
    description = "length of pet name in words"
    category = "terraform"
    workspace_id = tfe_workspace.workspace_name.id
}
```

[Local test results 02/10/2020](https://github.com/terraform-providers/terraform-provider-tfe/files/4182713/var-desc-tests-02102020.txt)

<img width="489" alt="Screen Shot 2020-02-06 at 6 09 42 PM" src="https://user-images.githubusercontent.com/11901347/73986558-ebef0700-490b-11ea-89d2-cffdf5bed7a9.png">
