### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Description
+
+_Describe why you're making this change._
+
+## Testing plan
+
+1.  _Describe how to replicate_
+1.  _the conditions_
+1.  _under which your code performs its purpose,_
+1.  _including example Terraform configs where necessary._
+
+## External links
+
+_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
+
+- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
+- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
+- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)
+
+## Output from acceptance tests
+
+_Please run the full suite of acceptance tests locally and include the output here._
+
+```
+$ make testacc
+
+...
+```


### PR DESCRIPTION
## Description

This PR adds a pull request template 🎉 

## Testing plan

1. There isn't one but 
1. this is what it will look like.
1. ✅ 

## External links

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

```
$ make testacc

lots of output here
...
```