### PR TITLE
Lock provider to tfe v2.2

### DIFF
--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -24,7 +24,7 @@ import (
 
 const defaultHostname = "app.terraform.io"
 
-var tfeServiceIDs = []string{"tfe.v2.1", "tfe.v2"}
+var tfeServiceIDs = []string{"tfe.v2.2"}
 
 // Config is the structure of the configuration for the Terraform CLI.
 type Config struct {


### PR DESCRIPTION
## Description

A recent change that was merged caused issues for people that were on TFE < 2.2 (< 202001-1). This updates the provider to only support this release onward.

## Testing plan

What was happening prior to this fix (which should stop happening)

1.  Use TFE < 2.2 and Provider v0.12.0
1.  Try to create a `tfe_variable`
1.  Get `Resource not found`

## External links

- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/123)

## Output from acceptance tests

Again getting issues with running tests locally. Will continue to try to get that working prior to merge.

```
$ make testacc

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 30m
?   	github.com/terraform-providers/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFESSHKeyDataSource_basic
--- PASS: TestAccTFESSHKeyDataSource_basic (27.13s)
=== RUN   TestAccTFETeamAccessDataSource_basic
--- PASS: TestAccTFETeamAccessDataSource_basic (35.68s)
=== RUN   TestAccTFETeamDataSource_basic
--- PASS: TestAccTFETeamDataSource_basic (26.87s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (31.58s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (30.70s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (27.20s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_versionConstraints
--- PASS: TestProvider_versionConstraints (0.00s)
=== RUN   TestAccTFENotificationConfiguration_basic
--- PASS: TestAccTFENotificationConfiguration_basic (25.16s)
=== RUN   TestAccTFENotificationConfiguration_update
--- PASS: TestAccTFENotificationConfiguration_update (41.38s)
=== RUN   TestAccTFENotificationConfiguration_slackWithToken
--- PASS: TestAccTFENotificationConfiguration_slackWithToken (15.81s)
=== RUN   TestAccTFENotificationConfiguration_duplicateTriggers
--- PASS: TestAccTFENotificationConfiguration_duplicateTriggers (25.67s)
=== RUN   TestAccTFENotificationConfigurationImport
--- PASS: TestAccTFENotificationConfigurationImport (27.93s)
=== RUN   TestAccTFEOAuthClient_basic
--- PASS: TestAccTFEOAuthClient_basic (23.19s)
=== RUN   TestAccTFEOrganization_basic
--- PASS: TestAccTFEOrganization_basic (17.15s)
=== RUN   TestAccTFEOrganization_update
--- PASS: TestAccTFEOrganization_update (32.18s)
=== RUN   TestAccTFEOrganization_import
--- PASS: TestAccTFEOrganization_import (19.99s)
=== RUN   TestAccTFEOrganizationToken_basic
--- PASS: TestAccTFEOrganizationToken_basic (22.34s)
=== RUN   TestAccTFEOrganizationToken_existsWithoutForce
--- PASS: TestAccTFEOrganizationToken_existsWithoutForce (29.66s)
=== RUN   TestAccTFEOrganizationToken_existsWithForce
--- PASS: TestAccTFEOrganizationToken_existsWithForce (42.78s)
=== RUN   TestAccTFEOrganizationToken_import
--- PASS: TestAccTFEOrganizationToken_import (25.62s)
=== RUN   TestAccTFEPolicySetParameter_basic
--- PASS: TestAccTFEPolicySetParameter_basic (27.39s)
=== RUN   TestAccTFEPolicySetParameter_update
--- PASS: TestAccTFEPolicySetParameter_update (46.70s)
=== RUN   TestAccTFEPolicySetParameter_import
--- PASS: TestAccTFEPolicySetParameter_import (31.47s)
=== RUN   TestAccTFEPolicySet_basic
--- PASS: TestAccTFEPolicySet_basic (35.01s)
=== RUN   TestAccTFEPolicySet_update
--- PASS: TestAccTFEPolicySet_update (59.43s)
=== RUN   TestAccTFEPolicySet_updateEmpty
--- PASS: TestAccTFEPolicySet_updateEmpty (48.10s)
=== RUN   TestAccTFEPolicySet_updatePopulated
--- PASS: TestAccTFEPolicySet_updatePopulated (68.18s)
=== RUN   TestAccTFEPolicySet_updateToGlobal
--- PASS: TestAccTFEPolicySet_updateToGlobal (59.80s)
=== RUN   TestAccTFEPolicySet_updateToWorkspace
--- PASS: TestAccTFEPolicySet_updateToWorkspace (58.04s)
=== RUN   TestAccTFEPolicySet_vcs
--- PASS: TestAccTFEPolicySet_vcs (33.34s)
=== RUN   TestAccTFEPolicySetImport
--- PASS: TestAccTFEPolicySetImport (37.42s)
=== RUN   TestAccTFESentinelPolicy_basic
--- PASS: TestAccTFESentinelPolicy_basic (31.36s)
=== RUN   TestAccTFESentinelPolicy_update
--- PASS: TestAccTFESentinelPolicy_update (55.98s)
=== RUN   TestAccTFESentinelPolicy_import
--- PASS: TestAccTFESentinelPolicy_import (36.31s)
=== RUN   TestAccTFESSHKey_basic
--- PASS: TestAccTFESSHKey_basic (22.53s)
=== RUN   TestAccTFESSHKey_update
--- PASS: TestAccTFESSHKey_update (36.24s)
=== RUN   TestAccTFETeamAccess_basic
--- PASS: TestAccTFETeamAccess_basic (29.96s)
=== RUN   TestAccTFETeamAccess_import
--- PASS: TestAccTFETeamAccess_import (29.22s)
=== RUN   TestPackTeamMemberID
--- PASS: TestPackTeamMemberID (0.00s)
=== RUN   TestUnpackTeamMemberID
--- PASS: TestUnpackTeamMemberID (0.00s)
=== RUN   TestAccTFETeamMember_basic
--- FAIL: TestAccTFETeamMember_basic (14.43s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error adding user "admin" to team team-FticE5gv13u9cDXX: bad request

        admin is not a member of the organization

          on /var/folders/dw/1s9sxhs939lfg64dwy35sb9c0000gp/T/tf-test961419961/main.tf line 12:
          (source code not available)


=== RUN   TestAccTFETeamMember_import
--- FAIL: TestAccTFETeamMember_import (14.37s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error adding user "admin" to team team-hjYv6NgzKnfEr76u: bad request

        admin is not a member of the organization

          on /var/folders/dw/1s9sxhs939lfg64dwy35sb9c0000gp/T/tf-test767341907/main.tf line 12:
          (source code not available)


=== RUN   TestAccTFETeamMembers_basic
--- FAIL: TestAccTFETeamMembers_basic (14.86s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error adding users to team team-qb2yDqJRNNyygReB: bad request

        admin is not a member of the organization

          on /var/folders/dw/1s9sxhs939lfg64dwy35sb9c0000gp/T/tf-test166987517/main.tf line 12:
          (source code not available)


=== RUN   TestAccTFETeamMembers_update
--- FAIL: TestAccTFETeamMembers_update (14.97s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error adding users to team team-Nce8NNSAM4cnaVWU: bad request

        admin is not a member of the organization

          on /var/folders/dw/1s9sxhs939lfg64dwy35sb9c0000gp/T/tf-test268367415/main.tf line 12:
          (source code not available)


=== RUN   TestAccTFETeamMembers_import
--- FAIL: TestAccTFETeamMembers_import (14.12s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error adding users to team team-r3hgnsQpZC6DqtmF: bad request

        admin is not a member of the organization

          on /var/folders/dw/1s9sxhs939lfg64dwy35sb9c0000gp/T/tf-test844171137/main.tf line 12:
          (source code not available)


=== RUN   TestAccTFETeam_basic
--- PASS: TestAccTFETeam_basic (21.71s)
=== RUN   TestAccTFETeam_import
--- PASS: TestAccTFETeam_import (23.76s)
=== RUN   TestAccTFETeamToken_basic
--- PASS: TestAccTFETeamToken_basic (25.43s)
=== RUN   TestAccTFETeamToken_existsWithoutForce
--- PASS: TestAccTFETeamToken_existsWithoutForce (34.00s)
=== RUN   TestAccTFETeamToken_existsWithForce
--- PASS: TestAccTFETeamToken_existsWithForce (45.97s)
=== RUN   TestAccTFETeamToken_import
--- PASS: TestAccTFETeamToken_import (27.41s)
=== RUN   TestAccTFEVariable_basic
--- PASS: TestAccTFEVariable_basic (27.05s)
=== RUN   TestAccTFEVariable_update
--- PASS: TestAccTFEVariable_update (50.34s)
=== RUN   TestAccTFEVariable_import
--- PASS: TestAccTFEVariable_import (29.91s)
=== RUN   TestPackWorkspaceID
--- PASS: TestPackWorkspaceID (0.00s)
=== RUN   TestUnpackWorkspaceID
--- PASS: TestUnpackWorkspaceID (0.00s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (21.68s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (22.31s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (34.40s)
=== RUN   TestAccTFEWorkspace_update
--- FAIL: TestAccTFEWorkspace_update (31.59s)
    testing.go:568: Step 1 error: Check failed: Check 2/12 error: Bad operations: true
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (36.26s)
=== RUN   TestAccTFEWorkspace_sshKey
```