### PR TITLE
Add support for run triggers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,7 @@
 module github.com/terraform-providers/terraform-provider-tfe
 
-// TODO: remove this line before PR
-replace github.com/hashicorp/go-tfe => /Users/lafentres/Code/HashiCorp/golang/go-tfe
-
 require (
-	github.com/hashicorp/go-tfe v0.4.0
+	github.com/hashicorp/go-tfe v0.5.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/terraform-providers/terraform-provider-tfe
 
+// TODO: remove this line before PR
+replace github.com/hashicorp/go-tfe => /Users/lafentres/Code/HashiCorp/golang/go-tfe
+
 require (
 	github.com/hashicorp/go-tfe v0.4.0
 	github.com/hashicorp/go-version v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
-github.com/hashicorp/go-tfe v0.4.0 h1:p5eh7MhrJ5ysAQaq4sbWg/eVJ94qtrqFJWqlYZZhgLE=
-github.com/hashicorp/go-tfe v0.4.0/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
+github.com/hashicorp/go-tfe v0.5.0 h1:8fKVNGdCziwZy0VtZkKmurYL7RJRPvGL9R72glwk6F8=
+github.com/hashicorp/go-tfe v0.5.0/go.mod h1:DVPSW2ogH+M9W1/i50ASgMht8cHP7NxxK0nrY9aFikQ=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -76,6 +76,7 @@ func Provider() terraform.ResourceProvider {
 			"tfe_organization_token":         resourceTFEOrganizationToken(),
 			"tfe_policy_set":                 resourceTFEPolicySet(),
 			"tfe_policy_set_parameter":       resourceTFEPolicySetParameter(),
+			"tfe_run_trigger":                resourceTFERunTrigger(),
 			"tfe_sentinel_policy":            resourceTFESentinelPolicy(),
 			"tfe_ssh_key":                    resourceTFESSHKey(),
 			"tfe_team":                       resourceTFETeam(),

--- a/tfe/resource_tfe_run_trigger.go
+++ b/tfe/resource_tfe_run_trigger.go
@@ -1,0 +1,96 @@
+package tfe
+
+import (
+	"fmt"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceTFERunTrigger() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTFERunTriggerCreate,
+		Read:   resourceTFERunTriggerRead,
+		Delete: resourceTFERunTriggerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"workspace_external_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"sourceable_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceTFERunTriggerCreate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// Get workspace
+	workspaceID := d.Get("workspace_external_id").(string)
+
+	// Get attributes
+	sourceableID := d.Get("sourceable_id").(string)
+
+	// Create a new options struct
+	options := tfe.RunTriggerCreateOptions{
+		Sourceable: &tfe.Workspace{
+			ID: sourceableID,
+		},
+	}
+
+	log.Printf("[DEBUG] Create run trigger on workspace %s with sourceable %s", workspaceID, sourceableID)
+	runTrigger, err := tfeClient.RunTriggers.Create(ctx, workspaceID, options)
+	if err != nil {
+		return fmt.Errorf("Error creating run trigger on workspace %s with sourceable %s: %v", workspaceID, sourceableID, err)
+	}
+
+	d.SetId(runTrigger.ID)
+
+	return resourceTFERunTriggerRead(d, meta)
+}
+
+func resourceTFERunTriggerRead(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Read run trigger: %s", d.Id())
+	runTrigger, err := tfeClient.RunTriggers.Read(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] run trigger %s no longer exists", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading run trigger %s: %v", d.Id(), err)
+	}
+
+	// Update config
+	d.Set("workspace_external_id", runTrigger.Workspace.ID)
+	d.Set("sourceable_id", runTrigger.Sourceable.ID)
+
+	return nil
+}
+
+func resourceTFERunTriggerDelete(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	log.Printf("[DEBUG] Delete run trigger: %s", d.Id())
+	err := tfeClient.RunTriggers.Delete(ctx, d.Id())
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			return nil
+		}
+		return fmt.Errorf("Error deleting run trigger %s: %v", d.Id(), err)
+	}
+
+	return nil
+}

--- a/tfe/resource_tfe_run_trigger_test.go
+++ b/tfe/resource_tfe_run_trigger_test.go
@@ -1,0 +1,135 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccTFERunTrigger_basic(t *testing.T) {
+	runTrigger := &tfe.RunTrigger{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERunTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERunTrigger_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFERunTriggerExists(
+						"tfe_run_trigger.foobar", runTrigger),
+					testAccCheckTFERunTriggerAttributes(runTrigger),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFERunTriggerImport(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFERunTriggerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFERunTrigger_basic,
+			},
+
+			{
+				ResourceName:      "tfe_run_trigger.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckTFERunTriggerExists(n string, runTrigger *tfe.RunTrigger) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		rt, err := tfeClient.RunTriggers.Read(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*runTrigger = *rt
+
+		return nil
+	}
+}
+
+func testAccCheckTFERunTriggerAttributes(runTrigger *tfe.RunTrigger) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+		workspaceID := runTrigger.Workspace.ID
+		workspace, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "workspace-test")
+		if workspace.ID != workspaceID {
+			return fmt.Errorf("Wrong workspace: %v", workspace.ID)
+		}
+
+		sourceableID := runTrigger.Sourceable.ID
+		sourceable, _ := tfeClient.Workspaces.Read(ctx, "tst-terraform", "sourceable-test")
+		if sourceable.ID != sourceableID {
+			return fmt.Errorf("Wrong sourceable: %v", sourceable.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckTFERunTriggerDestroy(s *terraform.State) error {
+	tfeClient := testAccProvider.Meta().(*tfe.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "tfe_run_trigger" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No instance ID is set")
+		}
+
+		_, err := tfeClient.RunTriggers.Read(ctx, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Notification configuration %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+const testAccTFERunTrigger_basic = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "workspace" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "sourceable" {
+  name         = "sourceable-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_run_trigger" "foobar" {
+  workspace_external_id = "${tfe_workspace.workspace.external_id}"
+  sourceable_id         = "${tfe_workspace.sourceable.external_id}"
+}`

--- a/vendor/github.com/hashicorp/go-tfe/README.md
+++ b/vendor/github.com/hashicorp/go-tfe/README.md
@@ -34,6 +34,7 @@ Currently the following endpoints are supported:
 - [x] [Policy Checks](https://www.terraform.io/docs/enterprise/api/policy-checks.html)
 - [ ] [Registry Modules](https://www.terraform.io/docs/enterprise/api/modules.html)
 - [x] [Runs](https://www.terraform.io/docs/enterprise/api/run.html)
+- [x] [Run Triggers](https://www.terraform.io/docs/cloud/api/run-triggers.html)
 - [x] [SSH Keys](https://www.terraform.io/docs/enterprise/api/ssh-keys.html)
 - [x] [State Versions](https://www.terraform.io/docs/enterprise/api/state-versions.html)
 - [x] [Team Access](https://www.terraform.io/docs/enterprise/api/team-access.html)

--- a/vendor/github.com/hashicorp/go-tfe/run_trigger.go
+++ b/vendor/github.com/hashicorp/go-tfe/run_trigger.go
@@ -1,0 +1,177 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ RunTriggers = (*runTriggers)(nil)
+
+// RunTriggers describes all the Run Trigger
+// related methods that the Terraform Cloud API supports.
+//
+// TFE API docs:
+// https://www.terraform.io/docs/cloud/api/run-triggers.html
+type RunTriggers interface {
+	// List all the run triggers within a workspace.
+	List(ctx context.Context, workspaceID string, options RunTriggerListOptions) (*RunTriggerList, error)
+
+	// Create a new run trigger with the given options.
+	Create(ctx context.Context, workspaceID string, options RunTriggerCreateOptions) (*RunTrigger, error)
+
+	// Read a run trigger by its ID.
+	Read(ctx context.Context, RunTriggerID string) (*RunTrigger, error)
+
+	// Delete a run trigger by its ID.
+	Delete(ctx context.Context, RunTriggerID string) error
+}
+
+// runTriggers implements RunTriggers.
+type runTriggers struct {
+	client *Client
+}
+
+// RunTriggerList represents a list of Run Triggers
+type RunTriggerList struct {
+	*Pagination
+	Items []*RunTrigger
+}
+
+// RunTrigger represents a run trigger.
+type RunTrigger struct {
+	ID             string    `jsonapi:"primary,run-triggers"`
+	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
+	SourceableName string    `jsonapi:"attr,sourceable-name"`
+	WorkspaceName  string    `jsonapi:"attr,workspace-name"`
+
+	// Relations
+	// TODO: this will eventually need to be polymorphic
+	Sourceable *Workspace `jsonapi:"relation,sourceable"`
+	Workspace  *Workspace `jsonapi:"relation,workspace"`
+}
+
+// RunTriggerListOptions represents the options for listing
+// run triggers.
+type RunTriggerListOptions struct {
+	ListOptions
+	RunTriggerType *string `url:"filter[run-trigger][type]"`
+}
+
+func (o RunTriggerListOptions) valid() error {
+	if !validString(o.RunTriggerType) {
+		return errors.New("run-trigger type is required")
+	}
+	if *o.RunTriggerType != "inbound" && *o.RunTriggerType != "outbound" {
+		return errors.New("invalid value for run-trigger type")
+	}
+	return nil
+}
+
+// List all the run triggers associated with a workspace.
+func (s *runTriggers) List(ctx context.Context, workspaceID string, options RunTriggerListOptions) (*RunTriggerList, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	rtl := &RunTriggerList{}
+	err = s.client.do(ctx, req, rtl)
+	if err != nil {
+		return nil, err
+	}
+
+	return rtl, nil
+}
+
+// RunTriggerCreateOptions represents the options for
+// creating a new run trigger.
+type RunTriggerCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,run-triggers"`
+
+	// The source workspace
+	Sourceable *Workspace `jsonapi:"relation,sourceable"`
+}
+
+func (o RunTriggerCreateOptions) valid() error {
+	if o.Sourceable == nil {
+		return errors.New("sourceable is required")
+	}
+	return nil
+}
+
+// Creates a run trigger with the given options.
+func (s *runTriggers) Create(ctx context.Context, workspaceID string, options RunTriggerCreateOptions) (*RunTrigger, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := &RunTrigger{}
+	err = s.client.do(ctx, req, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return rt, nil
+}
+
+// Read a run trigger by its ID.
+func (s *runTriggers) Read(ctx context.Context, runTriggerID string) (*RunTrigger, error) {
+	if !validStringID(&runTriggerID) {
+		return nil, errors.New("invalid value for run trigger ID")
+	}
+
+	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := &RunTrigger{}
+	err = s.client.do(ctx, req, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return rt, nil
+}
+
+// Delete a run trigger by its ID.
+func (s *runTriggers) Delete(ctx context.Context, runTriggerID string) error {
+	if !validStringID(&runTriggerID) {
+		return errors.New("invalid value for run trigger ID")
+	}
+
+	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -122,6 +122,7 @@ type Client struct {
 	PolicySetParameters        PolicySetParameters
 	PolicySets                 PolicySets
 	Runs                       Runs
+	RunTriggers                RunTriggers
 	SSHKeys                    SSHKeys
 	StateVersions              StateVersions
 	Teams                      Teams
@@ -215,6 +216,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.PolicySetParameters = &policySetParameters{client: client}
 	client.PolicySets = &policySets{client: client}
 	client.Runs = &runs{client: client}
+	client.RunTriggers = &runTriggers{client: client}
 	client.SSHKeys = &sshKeys{client: client}
 	client.StateVersions = &stateVersions{client: client}
 	client.Teams = &teams{client: client}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -97,7 +97,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.4.1
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.4.0
+# github.com/hashicorp/go-tfe v0.5.0
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid

--- a/website/docs/r/run_trigger.html.markdown
+++ b/website/docs/r/run_trigger.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_notification_configuration"
+sidebar_current: "docs-resource-tfe-run-trigger"
+description: |-
+  Manages run triggers
+---
+
+# tfe_run_trigger
+
+~> **Important:** This feature is currently in beta and not suggested for production use.
+
+Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, known as "source workspaces". 
+These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces. 
+You can connect your workspace to up to 20 source workspaces.
+
+## Example Usage
+
+Basic usage:
+
+```hcl
+resource "tfe_organization" "test-organization" {
+  name  = "my-org-name"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "test-workspace" {
+  name         = "my-workspace-name"
+  organization = "${tfe_organization.test-organization.id}"
+}
+
+resource "tfe_workspace" "test-sourceable" {
+  name         = "my-sourceable-workspace-name"
+  organization = "${tfe_organization.test-organization.id}"
+}
+
+resource "tfe_run_trigger" "test" {
+  workspace_external_id = "${tfe_workspace.test-workspace.external_id}"
+  sourceable_id         = "${tfe_workspace.test-sourceable.external_id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `workspace_external_id` - (Required) The external id of the workspace that owns the run trigger. This is the workspace where runs will be triggered.
+* `sourceable_id` - (Required) The external id of the sourceable. The sourceable must be a workspace.
+
+## Attributes Reference
+
+* `id` - The ID of the run trigger.
+
+## Import
+
+Run triggers can be imported; use `<RUN TRIGGER ID>` as the import ID. For example:
+
+```shell
+terraform import tfe_run_trigger.test rt-qV9JnKRkmtMa4zcA
+```

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -61,6 +61,10 @@
                             <a href="/docs/providers/tfe/r/policy_set_parameter.html">tfe_policy_set_parameter</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-resource-tfe-run-trigger") %>>
+                            <a href="/docs/providers/tfe/r/run_trigger.html">tfe_run_trigger</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-resource-tfe-sentinel-policy") %>>
                             <a href="/docs/providers/tfe/r/sentinel_policy.html">tfe_sentinel_policy</a>
                         </li>


### PR DESCRIPTION
## Description

This PR adds support and documentation for creating, destroying, and importing run triggers. 

#### Run trigger resources require:
1. workspace_external_id - external id of the workspace that owns the run trigger. This is the workspace where runs will be triggered.
1. sourceable_id - id of the sourceable. The sourceable must be a workspace.

Updating workspace_external_id or sourceable_id will force the creation of a new run trigger resource. 

## Testing plan

1. Build the provider by running `make build`
1. Move it to your Terraform plugins directory
   ```
   mv $GOPATH/bin/terraform-provider-tfe ~/.terraform.d/plugins
   ```
1. Copy this config, replace hostname and email values, and save it as `main.tf`. You'll be modifying it in the steps below. Make sure you have a user token added to your `~/.terraformrc` file for your TFC hostname. 
   ```
   provider "tfe" {
     hostname = "<YOUR_TFC_HERE>"
   }

   resource "tfe_organization" "run-triggers-organization" {
     name  = "run-triggers-provider-test"
     email = "<YOUR_EMAIL_HERE>"
   }

   resource "tfe_workspace" "workspace1" {
     name         = "workspace-test1"
     organization = tfe_organization.run-triggers-organization.id
   }

   resource "tfe_workspace" "workspace2" {
     name         = "workspace-test2"
     organization = tfe_organization.run-triggers-organization.id
   }

   resource "tfe_workspace" "workspace3" {
     name         = "workspace-test3"
     organization = tfe_organization.run-triggers-organization.id
   }

   resource "tfe_run_trigger" "run-trigger1" {
     workspace_external_id = tfe_workspace.workspace2.external_id
     sourceable_id         = tfe_workspace.workspace1.external_id
   }

   resource "tfe_run_trigger" "run-trigger2" {
     workspace_external_id = tfe_workspace.workspace3.external_id
     sourceable_id         = tfe_workspace.workspace2.external_id
   }
   ```
1.  Run `terraform init`.

#### Happy path:
1. Run `terraform apply`. This should succeed. Check that a run trigger has been created on workspace2 with a source workspace of workspace1. Check that a run trigger has been created on workspace3 with a source workspace of workspace2.

#### Loops: 
1. Add the following to the end of your config:
   ```
   resource "tfe_run_trigger" "run-trigger3" {
     workspace_external_id = tfe_workspace.workspace1.external_id
     sourceable_id         = tfe_workspace.workspace3.external_id
   }
   ```
1. Run `terraform apply`. This should fail with an error like the following:
   ```
   Error: Error creating run trigger on workspace ws-iAKEX2trrWtU4VjU with sourceable ws-Vtm7pFiZ4UNTKN8K: Invalid Attribute

   Run Trigger must not create a loop
   ```

#### Workspace and sourceable using same workspace
1. Change your `run-trigger3` resource block and make `workspace_external_id` and `sourceable_id` both point to workspace1:
   ```
   resource "tfe_run_trigger" "run-trigger3" {
     workspace_external_id = tfe_workspace.workspace1.external_id
     sourceable_id         = tfe_workspace.workspace1.external_id
   }
   ```
1. Run `terraform apply`. This should fail with an error like the following:
   ```
   Error: Error creating run trigger on workspace ws-iAKEX2trrWtU4VjU with sourceable ws-iAKEX2trrWtU4VjU: Invalid Attribute

   Sourceable can't be the same as workspace
   ```
1. Remove the `run-trigger3` resource block from your config before moving on to the next section.

#### Destroying run trigger
1. Remove the `run-trigger2` resource block from your config.
1. Run `terraform apply`. This should succeed and should destroy `run-trigger2`. Check that the run trigger on workspace3 with a source workspace of workspace2 was destroyed. 

#### Changing `workspace_external_id` forces new run trigger:
1. Change your `run-trigger1` resource block and make `workspace_external_id` to point to workspace3
   ```
   resource "tfe_run_trigger" "run-trigger1" {
     workspace_external_id = tfe_workspace.workspace3.external_id
     sourceable_id         = tfe_workspace.workspace1.external_id
   }
   ```
1. Run `terraform apply`. The output should show that one resource was added and 1 was destroyed. 
   ```
   Terraform will perform the following actions:

     # tfe_run_trigger.run-trigger1 must be replaced
   -/+ resource "tfe_run_trigger" "run-trigger1" {
         ~ id                    = "OLD_RUN_TRIGGER_ID" -> (known after apply)
           sourceable_id         = "WORKSPACE1_ID"
         ~ workspace_external_id = "WORKSPACE2_ID" -> "WORKSPACE3_ID" # forces replacement
       }

   Plan: 1 to add, 0 to change, 1 to destroy.

   Do you want to perform these actions?
     Terraform will perform the actions described above.
     Only 'yes' will be accepted to approve.

     Enter a value: yes

   tfe_run_trigger.run-trigger1: Destroying... [id=OLD_RUN_TRIGGER_ID]
   tfe_run_trigger.run-trigger1: Destruction complete after 0s
   tfe_run_trigger.run-trigger1: Creating...
   tfe_run_trigger.run-trigger1: Creation complete after 1s [id=NEW_RUN_TRIGGER_ID]

   Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
   ```

#### Changing `sourceable_id` forces new run trigger:
1. Change your `run-trigger1` resource block and make `sourceable_id` to point to workspace2
   ```
   resource "tfe_run_trigger" "run-trigger1" {
     workspace_external_id = tfe_workspace.workspace3.external_id
     sourceable_id         = tfe_workspace.workspace2.external_id
   }
   ```
1. Run `terraform apply`. The output should show that one resource was added and 1 was destroyed. 
   ```
   Terraform will perform the following actions:

     # tfe_run_trigger.run-trigger1 must be replaced
   -/+ resource "tfe_run_trigger" "run-trigger1" {
         ~ id                    = "OLD_RUN_TRIGGER_ID" -> (known after apply)
         ~ sourceable_id         = "WORKSPACE1_ID" -> "WORKSPACE2_ID" # forces replacement
           workspace_external_id = "WORKSPACE3_ID"
       }

   Plan: 1 to add, 0 to change, 1 to destroy.

   Do you want to perform these actions?
     Terraform will perform the actions described above.
     Only 'yes' will be accepted to approve.

     Enter a value: yes

   tfe_run_trigger.run-trigger1: Destroying... [id=OLD_RUN_TRIGGER_ID]
   tfe_run_trigger.run-trigger1: Destruction complete after 1s
   tfe_run_trigger.run-trigger1: Creating...
   tfe_run_trigger.run-trigger1: Creation complete after 0s [id=NEW_RUN_TRIGGER_ID]

   Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
   ```



## External links

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe@v0.5.0?tab=doc#RunTrigger)
- [API documentation](https://www.terraform.io/docs/cloud/api/run-triggers.html)
- [Cloud documentation](https://www.terraform.io/docs/cloud/workspaces/run-triggers.html)
- [Related go-tfe PR](https://github.com/hashicorp/go-tfe/pull/102)

## Output from acceptance tests

```
$ envchain terraform-provider-tfe make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 15m
?       github.com/terraform-providers/terraform-provider-tfe   [no test files]
=== RUN   TestAccTFESSHKeyDataSource_basic
--- PASS: TestAccTFESSHKeyDataSource_basic (8.68s)
=== RUN   TestAccTFETeamAccessDataSource_basic
--- PASS: TestAccTFETeamAccessDataSource_basic (13.35s)
=== RUN   TestAccTFETeamDataSource_basic
--- PASS: TestAccTFETeamDataSource_basic (7.86s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (12.19s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (12.65s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (8.29s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_versionConstraints
--- PASS: TestProvider_versionConstraints (0.00s)
=== RUN   TestAccTFENotificationConfiguration_basic
--- PASS: TestAccTFENotificationConfiguration_basic (8.19s)
=== RUN   TestAccTFENotificationConfiguration_update
--- PASS: TestAccTFENotificationConfiguration_update (13.32s)
=== RUN   TestAccTFENotificationConfiguration_slackWithToken
--- PASS: TestAccTFENotificationConfiguration_slackWithToken (4.43s)
=== RUN   TestAccTFENotificationConfiguration_duplicateTriggers
--- PASS: TestAccTFENotificationConfiguration_duplicateTriggers (7.96s)
=== RUN   TestAccTFENotificationConfigurationImport
--- PASS: TestAccTFENotificationConfigurationImport (8.25s)
=== RUN   TestAccTFEOAuthClient_basic
--- PASS: TestAccTFEOAuthClient_basic (7.21s)
=== RUN   TestAccTFEOrganization_basic
--- PASS: TestAccTFEOrganization_basic (9.99s)
=== RUN   TestAccTFEOrganization_update
--- PASS: TestAccTFEOrganization_update (8.23s)
=== RUN   TestAccTFEOrganization_import
--- PASS: TestAccTFEOrganization_import (5.28s)
=== RUN   TestAccTFEOrganizationToken_basic
--- PASS: TestAccTFEOrganizationToken_basic (6.77s)
=== RUN   TestAccTFEOrganizationToken_existsWithoutForce
--- PASS: TestAccTFEOrganizationToken_existsWithoutForce (8.77s)
=== RUN   TestAccTFEOrganizationToken_existsWithForce
--- PASS: TestAccTFEOrganizationToken_existsWithForce (12.17s)
=== RUN   TestAccTFEOrganizationToken_import
--- PASS: TestAccTFEOrganizationToken_import (7.46s)
=== RUN   TestAccTFEPolicySetParameter_basic
--- PASS: TestAccTFEPolicySetParameter_basic (9.76s)
=== RUN   TestAccTFEPolicySetParameter_update
--- PASS: TestAccTFEPolicySetParameter_update (20.24s)
=== RUN   TestAccTFEPolicySetParameter_import
--- PASS: TestAccTFEPolicySetParameter_import (9.85s)
=== RUN   TestAccTFEPolicySet_basic
--- PASS: TestAccTFEPolicySet_basic (10.53s)
=== RUN   TestAccTFEPolicySet_update
--- PASS: TestAccTFEPolicySet_update (18.49s)
=== RUN   TestAccTFEPolicySet_updateEmpty
--- PASS: TestAccTFEPolicySet_updateEmpty (14.50s)
=== RUN   TestAccTFEPolicySet_updatePopulated
--- PASS: TestAccTFEPolicySet_updatePopulated (25.96s)
=== RUN   TestAccTFEPolicySet_updateToGlobal
--- PASS: TestAccTFEPolicySet_updateToGlobal (17.75s)
=== RUN   TestAccTFEPolicySet_updateToWorkspace
--- PASS: TestAccTFEPolicySet_updateToWorkspace (18.24s)
=== RUN   TestAccTFEPolicySet_vcs
--- PASS: TestAccTFEPolicySet_vcs (13.83s)
=== RUN   TestAccTFEPolicySetImport
--- PASS: TestAccTFEPolicySetImport (15.38s)
=== RUN   TestAccTFERunTrigger_basic
--- PASS: TestAccTFERunTrigger_basic (9.23s)
=== RUN   TestAccTFERunTriggerImport
--- PASS: TestAccTFERunTriggerImport (9.16s)
=== RUN   TestAccTFESentinelPolicy_basic
--- PASS: TestAccTFESentinelPolicy_basic (9.35s)
=== RUN   TestAccTFESentinelPolicy_update
--- PASS: TestAccTFESentinelPolicy_update (19.17s)
=== RUN   TestAccTFESentinelPolicy_import
--- PASS: TestAccTFESentinelPolicy_import (10.35s)
=== RUN   TestAccTFESSHKey_basic
--- PASS: TestAccTFESSHKey_basic (11.71s)
=== RUN   TestAccTFESSHKey_update
--- PASS: TestAccTFESSHKey_update (11.13s)
=== RUN   TestAccTFETeamAccess_basic
--- PASS: TestAccTFETeamAccess_basic (9.64s)
=== RUN   TestAccTFETeamAccess_import
--- PASS: TestAccTFETeamAccess_import (10.19s)
=== RUN   TestPackTeamMemberID
--- PASS: TestPackTeamMemberID (0.00s)
=== RUN   TestUnpackTeamMemberID
--- PASS: TestUnpackTeamMemberID (0.00s)
=== RUN   TestAccTFETeamMember_basic
--- FAIL: TestAccTFETeamMember_basic (4.77s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error adding user "admin" to team team-7KzHoyQ1m7YrZu6v: bad request
        
        admin is not a member of the organization
        
          on /var/folders/jq/kcfxsqpd5hz_2cg_w9c_2hf40000gp/T/tf-test951146631/main.tf line 12:
          (source code not available)
        
        
=== RUN   TestAccTFETeamMember_import
--- FAIL: TestAccTFETeamMember_import (4.71s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error adding user "admin" to team team-J6M5hSneXQhotdtD: bad request
        
        admin is not a member of the organization
        
          on /var/folders/jq/kcfxsqpd5hz_2cg_w9c_2hf40000gp/T/tf-test112199761/main.tf line 12:
          (source code not available)
        
        
=== RUN   TestAccTFETeamMembers_basic
--- FAIL: TestAccTFETeamMembers_basic (4.56s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error adding users to team team-G3uDLdVTdx7TN8o8: bad request
        
        tfe_provider_1 is not a member of the organization
        
          on /var/folders/jq/kcfxsqpd5hz_2cg_w9c_2hf40000gp/T/tf-test922885291/main.tf line 12:
          (source code not available)
        
        
=== RUN   TestAccTFETeamMembers_update
--- FAIL: TestAccTFETeamMembers_update (4.76s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error adding users to team team-oB6hsA1GKWNwM6yw: bad request
        
        tfe_provider_1 is not a member of the organization
        
          on /var/folders/jq/kcfxsqpd5hz_2cg_w9c_2hf40000gp/T/tf-test234840597/main.tf line 12:
          (source code not available)
        
        
=== RUN   TestAccTFETeamMembers_import
--- FAIL: TestAccTFETeamMembers_import (4.67s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error adding users to team team-Z4MaL3yDkk1c3YQw: bad request
        
        tfe_provider_1 is not a member of the organization
        
          on /var/folders/jq/kcfxsqpd5hz_2cg_w9c_2hf40000gp/T/tf-test255988495/main.tf line 12:
          (source code not available)
        
        
=== RUN   TestAccTFETeam_basic
--- PASS: TestAccTFETeam_basic (7.17s)
=== RUN   TestAccTFETeam_import
--- PASS: TestAccTFETeam_import (12.07s)
=== RUN   TestAccTFETeamToken_basic
--- PASS: TestAccTFETeamToken_basic (8.42s)
=== RUN   TestAccTFETeamToken_existsWithoutForce
--- PASS: TestAccTFETeamToken_existsWithoutForce (11.27s)
=== RUN   TestAccTFETeamToken_existsWithForce
--- PASS: TestAccTFETeamToken_existsWithForce (14.56s)
=== RUN   TestAccTFETeamToken_import
--- PASS: TestAccTFETeamToken_import (8.55s)
=== RUN   TestAccTFEVariable_basic
--- PASS: TestAccTFEVariable_basic (10.04s)
=== RUN   TestAccTFEVariable_update
--- PASS: TestAccTFEVariable_update (21.51s)
=== RUN   TestAccTFEVariable_import
--- PASS: TestAccTFEVariable_import (10.21s)
=== RUN   TestPackWorkspaceID
--- PASS: TestPackWorkspaceID (0.00s)
=== RUN   TestUnpackWorkspaceID
--- PASS: TestUnpackWorkspaceID (0.00s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (6.56s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (6.63s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (10.08s)
=== RUN   TestAccTFEWorkspace_update
--- FAIL: TestAccTFEWorkspace_update (9.35s)
    testing.go:569: Step 1 error: Check failed: Check 2/12 error: Bad operations: true
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (10.80s)
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (21.97s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (7.17s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-tfe/tfe       646.696s
?       github.com/terraform-providers/terraform-provider-tfe/version   [no test files]
make: *** [testacc] Error 1
```