### PR TITLE
Update pull request template to add support for breaking changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,13 @@
 
 _Describe why you're making this change._
 
+## BREAKING CHANGE
+
+_Delete this section if your change is not introducing a breaking change to the provider or a breaking change from the TFE API_
+
+- [ ] New TFE API version created
+- [ ] Provider restricted to TFE API version
+
 ## Testing plan
 
 1.  _Describe how to replicate_

--- a/README.md
+++ b/README.md
@@ -151,4 +151,10 @@ Only update the `Unreleased` section. Please use the template below when updatin
 * r/tfe_resource: description of change or bug fix ([#124](link-to-PR))
 ```
 
-Change categories: `BUG FIXES`, `ENHANCEMENTS`, `FEATURES`, `NOTES`, `BREAKING CHANGES`
+### Change categories
+
+BREAKING CHANGES: Use this for any changes that aren't backwards compatible. Include details on how to handle these changes.
+FEATURES: Use this for any larger new features added
+ENHANCEMENTS: Use this for smaller new features added
+BUG FIXES: Use this for any bugs that were fixed
+NOTES: Use this section if you need to include any additional notes on things like upgrading, upcoming deprecations, or any other information you might want to highlight.

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ Only update the `Unreleased` section. Please use the template below when updatin
 * r/tfe_resource: description of change or bug fix ([#124](link-to-PR))
 ```
 
-Change categories: `BUG FIXES`, `ENHANCEMENTS`, `FEATURES`, `NOTES`, `BREAKING_CHANGE`
+Change categories: `BUG FIXES`, `ENHANCEMENTS`, `FEATURES`, `NOTES`, `BREAKING CHANGES`

--- a/README.md
+++ b/README.md
@@ -151,4 +151,4 @@ Only update the `Unreleased` section. Please use the template below when updatin
 * r/tfe_resource: description of change or bug fix ([#124](link-to-PR))
 ```
 
-Change categories: `BUG FIXES`, `ENHANCEMENTS`, `FEATURES`, `NOTES`
+Change categories: `BUG FIXES`, `ENHANCEMENTS`, `FEATURES`, `NOTES`, `BREAKING_CHANGE`


### PR DESCRIPTION
## Description

As part of the efforts to increase stability of the provider, we are adding further documentation around breaking changes. This PR updates the `README.md` to not that `BREAKING CHANGE` is also an available change category. Additionally, the pull request template has been updated with an _optional_ **Breaking Change** section. It's important to note that the creation of API versions can only be done internally within HashiCorp.