### PR TITLE
Workspace working directory updates

### DIFF
--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -132,6 +132,7 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 		Operations:          tfe.Bool(d.Get("operations").(bool)),
 		QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
+		WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 	}
 
 	// Process all configured options.
@@ -143,10 +144,6 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		for _, tp := range tps.([]interface{}) {
 			options.TriggerPrefixes = append(options.TriggerPrefixes, tp.(string))
 		}
-	}
-
-	if workingDir, ok := d.GetOk("working_directory"); ok {
-		options.WorkingDirectory = tfe.String(workingDir.(string))
 	}
 
 	// Get and assert the VCS repo configuration block.

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -76,7 +76,7 @@ func resourceTFEWorkspace() *schema.Resource {
 			"working_directory": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "",
 			},
 
 			"vcs_repo": {
@@ -321,6 +321,7 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 			FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 			Operations:          tfe.Bool(d.Get("operations").(bool)),
 			QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
+			WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 		}
 
 		// Process all configured options.

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -264,6 +264,34 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 						"tfe_workspace.foobar", "working_directory", "terraform/test"),
 				),
 			},
+			{
+				Config: testAccTFEWorkspace_updateWorkingDirectory,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					testAccCheckTFEWorkspaceAttributesUpdatedWorkingDirectory(workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "name", "workspace-updated"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "auto_apply", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "file_triggers_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "operations", "true"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "queue_all_runs", "false"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "terraform_version", "0.11.1"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "trigger_prefixes.#", "2"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "trigger_prefixes.0", "/modules"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "trigger_prefixes.1", "/shared"),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "working_directory", ""),
+				),
+			},
 		},
 	})
 }
@@ -507,6 +535,37 @@ func testAccCheckTFEWorkspaceAttributesUpdated(
 	}
 }
 
+func testAccCheckTFEWorkspaceAttributesUpdatedWorkingDirectory(
+	workspace *tfe.Workspace) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if workspace.Name != "workspace-updated" {
+			return fmt.Errorf("Bad name: %s", workspace.Name)
+		}
+
+		if workspace.AutoApply != false {
+			return fmt.Errorf("Bad auto apply: %t", workspace.AutoApply)
+		}
+
+		if workspace.Operations != true {
+			return fmt.Errorf("Here Bad operations: %t", workspace.Operations)
+		}
+
+		if workspace.QueueAllRuns != false {
+			return fmt.Errorf("Bad queue all runs: %t", workspace.QueueAllRuns)
+		}
+
+		if workspace.TerraformVersion != "0.11.1" {
+			return fmt.Errorf("Bad Terraform version: %s", workspace.TerraformVersion)
+		}
+
+		if workspace.WorkingDirectory != "" {
+			return fmt.Errorf("Today Bad working directory: %s", workspace.WorkingDirectory)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckTFEWorkspaceAttributesSSHKey(
 	workspace *tfe.Workspace) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -611,6 +670,22 @@ resource "tfe_workspace" "foobar" {
   terraform_version     = "0.11.1"
   trigger_prefixes      = ["/modules", "/shared"]
   working_directory     = "terraform/test"
+}`
+
+const testAccTFEWorkspace_updateWorkingDirectory = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name                  = "workspace-updated"
+  organization          = "${tfe_organization.foobar.id}"
+  auto_apply            = false
+  file_triggers_enabled = true
+  queue_all_runs        = false
+  terraform_version     = "0.11.1"
+  trigger_prefixes      = ["/modules", "/shared"]
 }`
 
 const testAccTFEWorkspace_sshKey = `

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -249,7 +249,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "file_triggers_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "operations", "false"),
+						"tfe_workspace.foobar", "operations", "true"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "queue_all_runs", "false"),
 					resource.TestCheckResourceAttr(
@@ -487,7 +487,7 @@ func testAccCheckTFEWorkspaceAttributesUpdated(
 			return fmt.Errorf("Bad auto apply: %t", workspace.AutoApply)
 		}
 
-		if workspace.Operations != false {
+		if workspace.Operations != true {
 			return fmt.Errorf("Bad operations: %t", workspace.Operations)
 		}
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -209,6 +209,7 @@ func TestAccTFEWorkspace_renamed(t *testing.T) {
 		},
 	})
 }
+
 func TestAccTFEWorkspace_update(t *testing.T) {
 	workspace := &tfe.Workspace{}
 
@@ -235,7 +236,6 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 						"tfe_workspace.foobar", "working_directory", ""),
 				),
 			},
-
 			{
 				Config: testAccTFEWorkspace_update,
 				Check: resource.ComposeTestCheckFunc(
@@ -249,7 +249,7 @@ func TestAccTFEWorkspace_update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "file_triggers_enabled", "true"),
 					resource.TestCheckResourceAttr(
-						"tfe_workspace.foobar", "operations", "true"),
+						"tfe_workspace.foobar", "operations", "false"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "queue_all_runs", "false"),
 					resource.TestCheckResourceAttr(
@@ -515,7 +515,7 @@ func testAccCheckTFEWorkspaceAttributesUpdated(
 			return fmt.Errorf("Bad auto apply: %t", workspace.AutoApply)
 		}
 
-		if workspace.Operations != true {
+		if workspace.Operations != false {
 			return fmt.Errorf("Bad operations: %t", workspace.Operations)
 		}
 


### PR DESCRIPTION
## Description

Added support for changing working directory for existing workspaces.

## Testing plan
If you create workspace with defined working directory and after apply you try to change it, provider will show there are no changes to be done. (working directory is computed value)
Issue reference #136 

## Output from acceptance tests
Changes were made to test `TestAccTFEWorkspace_update`

```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 15m
?   	github.com/terraform-providers/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFESSHKeyDataSource_basic
--- PASS: TestAccTFESSHKeyDataSource_basic (11.54s)
=== RUN   TestAccTFETeamAccessDataSource_basic
--- FAIL: TestAccTFETeamAccessDataSource_basic (9.51s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test-1002912244890962745 for organization tst-terraform-1002912244890962745: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test080338603/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamDataSource_basic
--- FAIL: TestAccTFETeamDataSource_basic (3.82s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test-4515755384739009815 for organization tst-terraform-4515755384739009815: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test354555413/main.tf line 7:
          (source code not available)
        
        
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: Could not find team tst-terraform-4515755384739009815/team-test-4515755384739009815
        
        State: <nil>
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (13.18s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (12.89s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (11.96s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestProvider_versionConstraints
--- PASS: TestProvider_versionConstraints (0.00s)
=== RUN   TestAccTFENotificationConfiguration_basic
--- PASS: TestAccTFENotificationConfiguration_basic (10.07s)
=== RUN   TestAccTFENotificationConfiguration_update
--- PASS: TestAccTFENotificationConfiguration_update (18.30s)
=== RUN   TestAccTFENotificationConfiguration_slackWithToken
--- PASS: TestAccTFENotificationConfiguration_slackWithToken (6.84s)
=== RUN   TestAccTFENotificationConfiguration_duplicateTriggers
--- PASS: TestAccTFENotificationConfiguration_duplicateTriggers (11.22s)
=== RUN   TestAccTFENotificationConfigurationImport
--- PASS: TestAccTFENotificationConfigurationImport (9.99s)
=== RUN   TestAccTFEOAuthClient_basic
--- SKIP: TestAccTFEOAuthClient_basic (0.76s)
    resource_tfe_oauth_client_test.go:19: Please set GITHUB_TOKEN to run this test
=== RUN   TestAccTFEOrganization_basic
--- PASS: TestAccTFEOrganization_basic (6.79s)
=== RUN   TestAccTFEOrganization_update
--- PASS: TestAccTFEOrganization_update (12.73s)
=== RUN   TestAccTFEOrganization_import
--- PASS: TestAccTFEOrganization_import (9.41s)
=== RUN   TestAccTFEOrganizationToken_basic
--- PASS: TestAccTFEOrganizationToken_basic (9.36s)
=== RUN   TestAccTFEOrganizationToken_existsWithoutForce
--- PASS: TestAccTFEOrganizationToken_existsWithoutForce (12.67s)
=== RUN   TestAccTFEOrganizationToken_existsWithForce
--- PASS: TestAccTFEOrganizationToken_existsWithForce (17.21s)
=== RUN   TestAccTFEOrganizationToken_import
--- PASS: TestAccTFEOrganizationToken_import (9.45s)
=== RUN   TestAccTFEPolicySetParameter_basic
--- FAIL: TestAccTFEPolicySetParameter_basic (4.88s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating policy set policy-set-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test986548502/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySetParameter_update
--- FAIL: TestAccTFEPolicySetParameter_update (6.70s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating policy set policy-set-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test383445688/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySetParameter_import
--- FAIL: TestAccTFEPolicySetParameter_import (3.78s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating policy set policy-set-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test933158570/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_basic
--- FAIL: TestAccTFEPolicySet_basic (3.90s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test411482476/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_update
--- FAIL: TestAccTFEPolicySet_update (5.28s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test048005502/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_updateEmpty
--- FAIL: TestAccTFEPolicySet_updateEmpty (6.13s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test653186912/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_updatePopulated
--- FAIL: TestAccTFEPolicySet_updatePopulated (6.18s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test072995730/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_updateToGlobal
--- FAIL: TestAccTFEPolicySet_updateToGlobal (7.83s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test374378644/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_updateToWorkspace
--- FAIL: TestAccTFEPolicySet_updateToWorkspace (8.11s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test211559654/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEPolicySet_vcs
--- SKIP: TestAccTFEPolicySet_vcs (0.38s)
    resource_tfe_policy_set_test.go:255: Please set GITHUB_TOKEN to run this test
=== RUN   TestAccTFEPolicySetImport
--- FAIL: TestAccTFEPolicySetImport (9.63s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-foo for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test945578760/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFERunTrigger_basic
--- PASS: TestAccTFERunTrigger_basic (11.39s)
=== RUN   TestAccTFERunTriggerImport
--- PASS: TestAccTFERunTriggerImport (10.88s)
=== RUN   TestAccTFESentinelPolicy_basic
--- FAIL: TestAccTFESentinelPolicy_basic (7.99s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test505657429/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFESentinelPolicy_update
--- FAIL: TestAccTFESentinelPolicy_update (4.33s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test173030735/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFESentinelPolicy_import
--- FAIL: TestAccTFESentinelPolicy_import (6.46s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating sentinel policy policy-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test364277337/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFESSHKey_basic
--- PASS: TestAccTFESSHKey_basic (9.17s)
=== RUN   TestAccTFESSHKey_update
--- PASS: TestAccTFESSHKey_update (15.64s)
=== RUN   TestAccTFETeamAccess_basic
--- FAIL: TestAccTFETeamAccess_basic (7.75s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test621783626/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamAccess_import
--- FAIL: TestAccTFETeamAccess_import (9.10s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test576932876/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestPackTeamMemberID
--- PASS: TestPackTeamMemberID (0.00s)
=== RUN   TestUnpackTeamMemberID
--- PASS: TestUnpackTeamMemberID (0.00s)
=== RUN   TestAccTFETeamMember_basic
--- FAIL: TestAccTFETeamMember_basic (5.23s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test026215198/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamMember_import
--- FAIL: TestAccTFETeamMember_import (3.73s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test999731200/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamMembers_basic
--- SKIP: TestAccTFETeamMembers_basic (0.38s)
    resource_tfe_team_members_test.go:22: Please set TFE_USER1 to run this test
=== RUN   TestAccTFETeamMembers_update
--- SKIP: TestAccTFETeamMembers_update (0.38s)
    resource_tfe_team_members_test.go:55: Please set TFE_USER1 to run this test
=== RUN   TestAccTFETeamMembers_import
--- SKIP: TestAccTFETeamMembers_import (1.39s)
    resource_tfe_team_members_test.go:102: Please set TFE_USER1 to run this test
=== RUN   TestAccTFETeam_basic
--- FAIL: TestAccTFETeam_basic (4.16s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test261097778/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeam_import
--- FAIL: TestAccTFETeam_import (4.55s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test325023540/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamToken_basic
--- FAIL: TestAccTFETeamToken_basic (4.97s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test230234758/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamToken_existsWithoutForce
--- FAIL: TestAccTFETeamToken_existsWithoutForce (6.57s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test710004648/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamToken_existsWithForce
--- FAIL: TestAccTFETeamToken_existsWithForce (7.37s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test684923162/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFETeamToken_import
--- FAIL: TestAccTFETeamToken_import (4.94s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: Error creating team team-test for organization tst-terraform: resource not found
        
          on /var/folders/cd/hq9glwbs4b72hkwl8kv2k2_jjp2x5y/T/tf-test055901532/main.tf line 7:
          (source code not available)
        
        
=== RUN   TestAccTFEVariable_basic
--- PASS: TestAccTFEVariable_basic (12.90s)
=== RUN   TestAccTFEVariable_update
--- PASS: TestAccTFEVariable_update (17.74s)
=== RUN   TestAccTFEVariable_import
--- PASS: TestAccTFEVariable_import (12.13s)
=== RUN   TestPackWorkspaceID
--- PASS: TestPackWorkspaceID (0.00s)
=== RUN   TestUnpackWorkspaceID
--- PASS: TestUnpackWorkspaceID (0.00s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (8.61s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (9.07s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (14.18s)
=== RUN   TestAccTFEWorkspace_update
--- PASS: TestAccTFEWorkspace_update (17.63s)
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (13.18s)
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (21.53s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (8.97s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-tfe/tfe	523.026s
?   	github.com/terraform-providers/terraform-provider-tfe/version	[no test files]
FAIL
make: *** [testacc] Error 1
...
```