### PR TITLE
Reset trigger prefixes for workspace resources when removed from the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.15.0 (Unreleased)
+## 0.14.1 (Unreleased)
+BUG FIXES:
+
+* t/tfe_workspace: Issues with updating `working_directory` and `trigger_prefixes` when removed from the configuration. Special note: if you have workspaces which are configured through the TFE provider, but have set the working directory or trigger prefixes manually, through the UI, you'll need to update your configuration.
+
 ## 0.14.0 (February 20, 2020)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 0.14.1 (Unreleased)
 BUG FIXES:
 
-* t/tfe_workspace: Issues with updating `working_directory` and `trigger_prefixes` when removed from the configuration. Special note: if you have workspaces which are configured through the TFE provider, but have set the working directory or trigger prefixes manually, through the UI, you'll need to update your configuration.
+* t/tfe_workspace: Issues with updating `working_directory` ([[#137](https://github.com/terraform-providers/terraform-provider-tfe/pull/137)]) 
+  and `trigger_prefixes` ([[#138](https://github.com/terraform-providers/terraform-provider-tfe/pull/138)]) when removed from the configuration. 
+  Special note: if you have workspaces which are configured through the TFE provider, but have set the working directory or trigger prefixes manually, through the UI, you'll need to update your configuration.
 
 ## 0.14.0 (February 20, 2020)
 

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -329,7 +329,6 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		if tps, ok := d.GetOk("trigger_prefixes"); ok {
 			for _, tp := range tps.([]interface{}) {
 				options.TriggerPrefixes = append(options.TriggerPrefixes, tp.(string))
-
 			}
 		} else {
 			// Reset trigger prefixes when none are present in the config.

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -329,7 +329,11 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 		if tps, ok := d.GetOk("trigger_prefixes"); ok {
 			for _, tp := range tps.([]interface{}) {
 				options.TriggerPrefixes = append(options.TriggerPrefixes, tp.(string))
+
 			}
+		} else {
+			// Reset trigger prefixes when none are present in the config.
+			options.TriggerPrefixes = []string{}
 		}
 
 		if workingDir, ok := d.GetOk("working_directory"); ok {

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -735,6 +735,7 @@ resource "tfe_workspace" "foobar" {
   terraform_version     = "0.11.1"
   trigger_prefixes      = ["/modules", "/shared"]
   working_directory     = "terraform/test"
+  operations            = false
 }`
 
 const testAccTFEWorkspace_updateAddWorkingDirectory = `


### PR DESCRIPTION
## Description

Fixes a bug for `tfe_workspace` resource updates. Previously when creating a `tfe_workspace` resource with a `trigger_prefixes` configuration, this option remained even when the `trigger_prefixes` config option was removed during subsequent updates to this resource. `terraform plan` would continue outputting this change, but it would not take effect.

## Testing plan

``` 
 # tfe_workspace.pleng_staging_us_west_2 will be updated in-place
  ~ resource "tfe_workspace" "pleng_staging_us_west_2" {
        auto_apply            = false
        external_id           = "ws-6YmtKxQffbqJpVE6"
        file_triggers_enabled = true
        id                    = "chavo4/pleng-staging-us-west-2"
        name                  = "pleng-staging-us-west-2"
        operations            = true
        organization          = "chavo4"
        queue_all_runs        = true
        terraform_version     = "0.12.12"
      ~ trigger_prefixes      = [
          - "567694625192/us-west-2",
        ]
        working_directory     = "567694625192/us-west-3"

        vcs_repo {
            identifier         = "nicsnet/terraform-provider-nics"
            ingress_submodules = false
            oauth_token_id     = "#######"
        }
    }
````

## Output from acceptance tests

_Please run the full suite of acceptance tests locally and include the output here._

```
$ make testacc

...
```