### PR TITLE
Remove beta flag from tfe_run_trigger resource documentation

### DIFF
--- a/website/docs/r/run_trigger.html.markdown
+++ b/website/docs/r/run_trigger.html.markdown
@@ -8,8 +8,6 @@ description: |-
 
 # tfe_run_trigger
 
-~> **Important:** This feature is currently in beta and not suggested for production use.
-
 Terraform Cloud provides a way to connect your workspace to one or more workspaces within your organization, known as "source workspaces". 
 These connections, called run triggers, allow runs to queue automatically in your workspace on successful apply of runs in any of the source workspaces. 
 You can connect your workspace to up to 20 source workspaces.


### PR DESCRIPTION
## Description

We've moved this feature out of beta so all the docs need to be updated to reflect this. 

## Testing plan

This is just a documentation change, no testing needed. 

## External links

- [Related PR - TF Cloud & API doc update](https://github.com/hashicorp/terraform-website/pull/1163)

## Output from acceptance tests

Just a documentation update, so no need to run the tests. 