### PR TITLE
Add documentation on constraining provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,33 @@ $ make build
 
 ## Using the provider
 
+For production use, you should constrain the acceptable provider versions via configuration,
+to ensure that new versions with breaking changes will not be automatically installed by 
+`terraform init` in future. As this provider is still at version zero, you should constrain 
+the acceptable provider versions on the minor version.
+
+If you are using Terraform CLI version 0.12.x, you can constrain this provider to 0.15.x versions 
+by adding a `required_providers` block inside a `terraform` block.
+```
+terraform {
+  required_providers {
+    tfe = "~> 0.15.0"
+  }
+}
+```
+
+If you are using Terraform CLI version 0.11.x, you can constrain this provider to 0.15.x versions 
+by adding the version constraint to the tfe provider block.
+```
+provider "tfe" {
+  version = "~> 0.15.0"
+  ...
+}
+```
+
+For more information on constraining provider versions, see the 
+[provider versions documentation](https://www.terraform.io/docs/configuration/providers.html#provider-versions).
+
 If you're building the provider, follow the instructions to
 [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin)
 After placing it into your plugins directory,  run `terraform init` to initialize it.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,6 +15,10 @@ It supports both the SaaS version of Terraform Enterprise
 
 Use the navigation to the left to read about the available resources.
 
+~> **Important:** For production use, you should constrain the acceptable provider versions via configuration,
+to ensure that new versions with breaking changes will not be automatically installed. 
+For more information, see [Versions](#versions).
+
 ## Authentication
 
 This provider requires a Terraform Enterprise API token in order to manage
@@ -41,6 +45,36 @@ There are three ways to provide the required token:
 - In a Terraform Enterprise workspace, set `token` in the provider
   configuration. Use an input variable for the token and mark the corresponding
   variable in the workspace as sensitive.
+  
+## Versions
+
+For production use, you should constrain the acceptable provider versions via configuration,
+to ensure that new versions with breaking changes will not be automatically installed by 
+`terraform init` in future. As this provider is still at version zero, you should constrain 
+the acceptable provider versions on the minor version.
+
+If you are using Terraform CLI version 0.12.x, you can constrain this provider to 0.15.x versions 
+by adding a `required_providers` block inside a `terraform` block.
+```
+terraform {
+  required_providers {
+    tfe = "~> 0.15.0"
+  }
+}
+```
+
+If you are using Terraform CLI version 0.11.x, you can constrain this provider to 0.15.x versions 
+by adding the version constraint to the tfe provider block.
+```
+provider "tfe" {
+  version = "~> 0.15.0"
+  ...
+}
+```
+
+For more information on constraining provider versions, see the 
+[provider versions documentation](https://www.terraform.io/docs/configuration/providers.html#provider-versions).
+  
 
 ## Example Usage
 
@@ -49,6 +83,7 @@ There are three ways to provide the required token:
 provider "tfe" {
   hostname = "${var.hostname}"
   token    = "${var.token}"
+  version  = "~> 0.15.0"
 }
 
 # Create an organization


### PR DESCRIPTION
## Description

Our documentation should be more explicit about the recommendation to pin versions for production use of any provider. I've added some documentation to the README and to the website documentation as well. 

## Testing plan

1. This is a documentation change, so just make sure the links I've added all work. 

## External links

I pulled the wording for this from existing documentation about constraining provider versions. Here are the docs I used:
- [Provider versions](https://www.terraform.io/docs/configuration/providers.html#provider-versions)
- [Specifying required provider versions](https://www.terraform.io/docs/configuration/terraform.html#specifying-required-provider-versions)

## Output from acceptance tests

This is a documentation only change, so no need to run the acceptance tests. 