### PR TITLE
tfe_workspace fix panic if resource not found

### DIFF
--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -200,7 +200,11 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 	log.Printf("[DEBUG] Read configuration of workspace: %s", id)
 	workspace, err := tfeClient.Workspaces.ReadByID(ctx, id)
-	if err != nil && err != tfe.ErrResourceNotFound {
+	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error reading configuration of workspace %s: %v", id, err)
 	}
 


### PR DESCRIPTION
## Description

Fix a crash/panic when trying to re-create a workspace that was deleted outside of Terraform.

Fixes #149 

## Testing plan

1.  Create a `tfe_workspace` with and run `terraform apply`
2.  Delete the workspace manually in Terraform Cloud
3.  Run `terraform apply` again with not changes 
4.  Validate that Terraform detects that the resource doesn't exist and re-creates the workspace without crashing

## Output from acceptance tests

I did not run the full suite of acceptance tests since this only touches one resource. Hopefully that's okay.

```
TESTARGS="-run TestAccTFEWorkspace" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace -timeout 15m
?   	github.com/terraform-providers/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (9.55s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (8.54s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (7.34s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (6.21s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (6.37s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (8.98s)
=== RUN   TestAccTFEWorkspace_update
--- PASS: TestAccTFEWorkspace_update (11.02s)
=== RUN   TestAccTFEWorkspace_updateWorkingDirectory
--- PASS: TestAccTFEWorkspace_updateWorkingDirectory (13.64s)
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (9.66s)
=== RUN   TestAccTFEWorkspace_updateTriggerPrefixes
--- PASS: TestAccTFEWorkspace_updateTriggerPrefixes (11.17s)
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (15.88s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (7.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tfe/tfe	116.906s
?   	github.com/terraform-providers/terraform-provider-tfe/version	[no test files]
...
```