### PR TITLE
docs: update import ID for tfe_workspace

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -63,9 +63,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Workspaces can be imported; use `<ORGANIZATION NAME>/<WORKSPACE NAME>` as the
+Workspaces can be imported; use `<WORKSPACE ID>` as the
 import ID. For example:
 
 ```shell
-terraform import tfe_workspace.test my-org-name/my-workspace-name
+terraform import tfe_workspace.test ws-CH5in3chf8RJjrVd
 ```


### PR DESCRIPTION
## Description

Workspaces use their random `ws-*` ID values as their ID attribute in Terraform, rather than `<org>/<name>` . This updates the docs to match.

## External links

- Original PR that modified IDs: #106
- Closes #153