### PR TITLE
[docs] update tfe_workspace import docs to use workspace id

### DIFF
--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -63,9 +63,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Workspaces can be imported; use `<ORGANIZATION NAME>/<WORKSPACE NAME>` as the
+Workspaces can be imported; use `<ORGANIZATION NAME>/<WORKSPACE ID>` as the
 import ID. For example:
 
 ```shell
-terraform import tfe_workspace.test my-org-name/my-workspace-name
+terraform import tfe_workspace.test my-org-name/my-workspace-id
 ```

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -63,9 +63,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Workspaces can be imported; use `<ORGANIZATION NAME>/<WORKSPACE ID>` as the
-import ID. For example:
+Workspaces can be imported; use `<WORKSPACE ID>` as the import ID. For example:
 
 ```shell
-terraform import tfe_workspace.test my-org-name/my-workspace-id
+terraform import tfe_workspace.test my-workspace-id
 ```


### PR DESCRIPTION
## Description

It seems that workspace ID, rather than name, is now required for an import.

I was following the directions to do an import and discovered that using the workspace name does not work, but the workspace ID does.

## Testing plan

This is just a documentation change, so no testing required?
