### PR TITLE
Update docs to reflect changes to workspace IDs + fix broken code block

### DIFF
--- a/website/docs/d/workspace_ids.html.markdown
+++ b/website/docs/d/workspace_ids.html.markdown
@@ -39,6 +39,12 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `ids` - A map of workspace names and their IDs.
+~> **NOTE** In versions < 0.15.1, workspace IDs were in the format 
+`<ORGANIZATION NAME>/<WORKSPACE NAME>` for some resources. This format 
+has been deprecated in favor of the immutable workspace ID in the format `ws-<RANDOM STRING>`.
+The `ids` attribute for this resource return workspace IDs in the deprecated
+format so you should use `external_ids` instead.
+
+* `ids` - A map of workspace names and their human-readable IDs, which look like `<ORGANIZATION>/<WORKSPACE>`. 
 * `external_ids` - A map of workspace names and their opaque external IDs, which
   look like `ws-<RANDOM STRING>`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -55,7 +55,8 @@ the acceptable provider versions on the minor version.
 
 If you are using Terraform CLI version 0.12.x, you can constrain this provider to 0.15.x versions 
 by adding a `required_providers` block inside a `terraform` block.
-```
+
+```hcl
 terraform {
   required_providers {
     tfe = "~> 0.15.0"
@@ -65,7 +66,8 @@ terraform {
 
 If you are using Terraform CLI version 0.11.x, you can constrain this provider to 0.15.x versions 
 by adding the version constraint to the tfe provider block.
-```
+
+```hcl
 provider "tfe" {
   version = "~> 0.15.0"
   ...

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -63,6 +63,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
+~> **NOTE** In versions < 0.15.1, the import ID was in the format `<ORGANIZATION NAME>/<WORKSPACE NAME>`.
+This format has been deprecated in favor of the immutable workspace ID in the format `ws-<RANDOM STRING>`.
+
 Workspaces can be imported; use `<WORKSPACE ID>` as the
 import ID. For example:
 


### PR DESCRIPTION
## Description

This PR updates the docs to explain the different between `ids` and `external_ids` on the tfe_workspace_ids data source. Workspace IDs in the format `<ORG NAME>/<WORKSPACE NAME>` were deprecated in https://github.com/terraform-providers/terraform-provider-tfe/pull/106.

I also added notes in a few other places explaining that workspace IDs used to be different. 

I noticed some broken code blocks on the provider docs index page, so I went ahead and fixed those as well. 

## Testing plan

1.  This is a documentation only change, so no test steps necessary.

## External links

- [Workspace ID Migration PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/106)

## Output from acceptance tests

This is a documentation only change, so no tests necessary.