### PR TITLE
add ValidateFunc to resourceTFEPolicySet to catch syntax errors at tf plan time

### DIFF
--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -7,6 +7,7 @@ import (
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceTFEPolicySet() *schema.Resource {
@@ -21,19 +22,9 @@ func resourceTFEPolicySet() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
-					value := v.(string)
-					matched, err := regexp.Match(`^[A-Za-z\d-_]+$`, []byte(value))
-					if err != nil {
-						errs = append(errs, err)
-					}
-					if !matched {
-						errs = append(errs, fmt.Errorf("policy set name %s should only contain letters, numbers, dashes (-) and underscores (_)", value))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w\.\-]+$`), "The name of the policy set. Can only include letters, numbers, -, and _."),
 			},
 
 			"description": {

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -22,6 +23,17 @@ func resourceTFEPolicySet() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errs []error) {
+					value := v.(string)
+					matched, err := regexp.Match(`^[A-Za-z\d-_]+$`, []byte(value))
+					if err != nil {
+						errs = append(errs, err)
+					}
+					if !matched {
+						errs = append(errs, fmt.Errorf("policy set name %s should only contain letters, numbers, dashes (-) and underscores (_)", value))
+					}
+					return
+				},
 			},
 
 			"description": {

--- a/tfe/resource_tfe_policy_set.go
+++ b/tfe/resource_tfe_policy_set.go
@@ -24,7 +24,7 @@ func resourceTFEPolicySet() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w\.\-]+$`), "The name of the policy set. Can only include letters, numbers, -, and _."),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`\A[\w\_\-]+\z`), "can only include letters, numbers, -, and _."),
 			},
 
 			"description": {

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -454,7 +454,7 @@ func TestAccTFEPolicySet_invalidname(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTFEPolicySet_invalidname,
-				ExpectError: regexp.MustCompile(`policy set name not the right format should only contain`),
+				ExpectError: regexp.MustCompile(`The name of the policy set. Can only include letters, numbers, -, and _.`),
 			},
 		},
 	})

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -446,15 +446,15 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func TestAccTFEPolicySet_invalidname(t *testing.T) {
+func TestAccTFEPolicySet_invalidName(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTFEPolicySetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccTFEPolicySet_invalidname,
-				ExpectError: regexp.MustCompile(`The name of the policy set. Can only include letters, numbers, -, and _.`),
+				Config:      testAccTFEPolicySet_invalidName,
+				ExpectError: regexp.MustCompile(`can only include letters, numbers, -, and _.`),
 			},
 		},
 	})
@@ -607,7 +607,7 @@ resource "tfe_policy_set" "foobar" {
 	GITHUB_POLICY_SET_PATH,
 )
 
-const testAccTFEPolicySet_invalidname = `
+const testAccTFEPolicySet_invalidName = `
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform"
   email = "admin@company.com"

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -445,6 +446,20 @@ func testAccCheckTFEPolicySetDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccTFEPolicySet_invalidname(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEPolicySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTFEPolicySet_invalidname,
+				ExpectError: regexp.MustCompile(`policy set name not the right format should only contain`),
+			},
+		},
+	})
+}
+
 const testAccTFEPolicySet_basic = `
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform"
@@ -591,3 +606,11 @@ resource "tfe_policy_set" "foobar" {
 	GITHUB_POLICY_SET_BRANCH,
 	GITHUB_POLICY_SET_PATH,
 )
+
+const testAccTFEPolicySet_invalidname = `
+resource "tfe_policy_set" "foobar" {
+  name         = "not the right format"
+  description  = "Policy Set"
+  organization = "${tfe_organization.foobar.id}"
+  policy_ids   = ["${tfe_sentinel_policy.foo.id}"]
+}`

--- a/tfe/resource_tfe_policy_set_test.go
+++ b/tfe/resource_tfe_policy_set_test.go
@@ -608,6 +608,17 @@ resource "tfe_policy_set" "foobar" {
 )
 
 const testAccTFEPolicySet_invalidname = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_sentinel_policy" "foo" {
+  name         = "policy-foo"
+  policy       = "main = rule { true }"
+  organization = "${tfe_organization.foobar.id}"
+}
+
 resource "tfe_policy_set" "foobar" {
   name         = "not the right format"
   description  = "Policy Set"


### PR DESCRIPTION
## Description

When using terraform, it can be frustrating to have a plan complete successfully as part of PR validation processes, only to have it fail after merged and attempting to apply.  In this case, using a `name` for `tfe_policy_set` that includes a space would pass PR validation but throw an error on apply as the name should only contain letters, numbers, dash, and underscore as specified in the UI.

## Testing plan

```
TESTARGS="-run TestAccTFEPolicySet_invalidname" make testacc
```

## Output from acceptance tests

Apologies for only running a targeted test here instead of a full suite, but I do not yet have a full acceptance test environment setup.

```
$ TESTARGS="-run TestAccTFEPolicySet_invalidname" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEPolicySet_invalidname -timeout 15m
?   	github.com/terraform-providers/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEPolicySet_invalidname
--- PASS: TestAccTFEPolicySet_invalidname (0.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tfe/tfe	(cached)
?   	github.com/terraform-providers/terraform-provider-tfe/version	[no test files]
```