### PR TITLE
Providing guidance on tfe_workspace operations

### DIFF
--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -34,7 +34,7 @@ In addition to all arguments above, the following attributes are exported:
 * `auto_apply` - Indicates whether to automatically apply changes when a
   Terraform plan is successful.
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
-* `operations` - Indicates whether the workspace is using remote execution mode.
+* `operations` - Indicates whether the workspace is using remote execution mode. Set to `false` to switch execution mode to local. `true` by default.
 * `queue_all_runs` - Indicates whether all runs should be queued.
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
 * `terraform_version` - The version of Terraform used for this workspace.


### PR DESCRIPTION
## Description

This is a small documentation change for the TFE/TFC Provider documentation to clarify the `operations` attribute. It is `boolean` but that's unclear from the current documentation. This updates provides that clarity and includes the default behaviour for further guidance.

https://www.terraform.io/docs/providers/tfe/d/workspace.html#attributes-reference lacked guidance on the `operations` attribute of the `tfe_workspace` resource.
