### PR TITLE
variable: use ForceNew for key changes on sensitive variables

### DIFF
--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -83,13 +84,9 @@ func resourceTFEVariable() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: func(diff *schema.ResourceDiff, m interface{}) error {
-			if diff.Get("sensitive").(bool) {
-				diff.ForceNew("key")
-			}
-
-			return nil
-		},
+		CustomizeDiff: customdiff.ForceNewIf("key", func(d *schema.ResourceDiff, m interface{}) bool {
+			return d.Get("sensitive").(bool)
+		}),
 	}
 }
 

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -28,12 +28,10 @@ func resourceTFEVariable() *schema.Resource {
 				Version: 0,
 			},
 		},
-
 		Schema: map[string]*schema.Schema{
 			"key": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"value": {
@@ -83,6 +81,14 @@ func resourceTFEVariable() *schema.Resource {
 					"must be the workspace's external_id",
 				),
 			},
+		},
+
+		CustomizeDiff: func(diff *schema.ResourceDiff, m interface{}) error {
+			if diff.Get("sensitive").(bool) {
+				diff.ForceNew("key")
+			}
+
+			return nil
 		},
 	}
 }

--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -33,6 +33,7 @@ func resourceTFEVariable() *schema.Resource {
 			"key": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"value": {

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/compose.go
@@ -1,0 +1,72 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/computed.go
@@ -1,0 +1,16 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/condition.go
@@ -1,0 +1,60 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(old, new, meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if cond(d.Get(key), meta) {
+			return f(d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/force_new.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		if f(d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff/validate.go
@@ -1,0 +1,38 @@
+package customdiff
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(val, meta)
+	}
+}


### PR DESCRIPTION
## Description

**Scenario:** A user creates a `tfe_variable` with `sensitive = true` but sets the wrong key. They go back later to set the correct key, changing it in place in the Terraform configuration.
**Expected:** The variable is updated
**Result:** An API error that causes the resource update to fail

```
Error: Error updating variable var-cM2eQjsuDNpYHtw3: Invalid Attribute

Key cannot be updated for a sensitive variable
```

I can imagine why this limitation exists for sensitive (i.e. transit-encrypted) values. ~While it's possible to update non-sensitive values in place, split behavior seems confusing and the code involved would be a lot more complex (i.e. conditionally calling `Delete` and `Create`). There's no way to tell a user that a delete + create is happening other than `ForceNew`.~

**Edit**: This should be using the [`ForceNew`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/helper/schema?tab=doc#ResourceDiff.ForceNew) method

Closes #170

## Testing plan

1.  Apply with config that is valid but contains a mistake

```tf
resource "tfe_variable" "api_key" {
  key          = "AP_KEY"
  value        = "the_api_key"
  sensitive    = true
  category     = "env"
}
```

2. Fix the config

```tf
resource "tfe_variable" "api_key" {
  key          = "API_KEY"
  value        = "the_api_key"
  sensitive    = true
  category     = "env"
}
```

3. Apply again

## Output from acceptance tests


```
$ TESTARGS="-run TestAccTFEVariable_update" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEVariable_update -timeout 15m
?   	github.com/terraform-providers/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEVariable_update
--- PASS: TestAccTFEVariable_update (10.02s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tfe/tfe	10.268s
?   	github.com/terraform-providers/terraform-provider-tfe/version	[no test files]
```