### PR TITLE
team: allow OrganizationAccess to be nil

### DIFF
--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -123,10 +123,13 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Update the config.
 	d.Set("name", team.Name)
-	d.Set("organization_access.0.manage_policies", team.OrganizationAccess.ManagePolicies)
-	d.Set("organization_access.0.manage_workspaces", team.OrganizationAccess.ManageWorkspaces)
-	d.Set("organization_access.0.manage_vcs_settings", team.OrganizationAccess.ManageVCSSettings)
 	d.Set("visibility", team.Visibility)
+	
+	if team.OrganizationAccess != nil {
+		d.Set("organization_access.0.manage_policies", team.OrganizationAccess.ManagePolicies)
+		d.Set("organization_access.0.manage_workspaces", team.OrganizationAccess.ManageWorkspaces)
+		d.Set("organization_access.0.manage_vcs_settings", team.OrganizationAccess.ManageVCSSettings)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

Handles `tfe_team` responses that omit an organization access object, which only happens when you try to manage an "owners" team on a free Terraform Cloud plan. That's not actually useful but the provider shouldn't crash either.

Closes #179, follows #155

## Testing plan

1.  Import the owners team on a free TF Cloud account

FYI @chrisarcand 