### PR TITLE
Fix organization access panic + state thrashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 0.18.0 (Unreleased)
+
+BUG FIXES:
+* r/tfe_team: Fixed a panic occurring with importing Owners teams on Free TFC organizations which do not include visible organization access. ([#181](https://github.com/terraform-providers/terraform-provider-tfe/pull/181))
+
 ## 0.17.0 (May 21, 2020)
 
 ENHANCEMENTS:

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -36,6 +36,7 @@ func resourceTFETeam() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"manage_policies": {

--- a/tfe/resource_tfe_team.go
+++ b/tfe/resource_tfe_team.go
@@ -123,9 +123,16 @@ func resourceTFETeamRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Update the config.
 	d.Set("name", team.Name)
-	d.Set("organization_access.0.manage_policies", team.OrganizationAccess.ManagePolicies)
-	d.Set("organization_access.0.manage_workspaces", team.OrganizationAccess.ManageWorkspaces)
-	d.Set("organization_access.0.manage_vcs_settings", team.OrganizationAccess.ManageVCSSettings)
+	if team.OrganizationAccess != nil {
+		organizationAccess := []map[string]bool{{
+			"manage_policies":     team.OrganizationAccess.ManagePolicies,
+			"manage_workspaces":   team.OrganizationAccess.ManageWorkspaces,
+			"manage_vcs_settings": team.OrganizationAccess.ManageVCSSettings,
+		}}
+		if err := d.Set("organization_access", organizationAccess); err != nil {
+			return fmt.Errorf("error setting organization access for team %s: %s", d.Id(), err)
+		}
+	}
 	d.Set("visibility", team.Visibility)
 
 	return nil


### PR DESCRIPTION
## Description

Fixes #179 

* Organization access is not always returned by the API, even for owners - if the organization is on the Free plan. These should not be attempted to be updated in state in this case, or a panic will occur.
* Organization access, when _not_ specified in the configuration (because it is optional), should be marked as computed. This updates state with the API response and avoids thrashing on the next plan, when the plan attempts to nullify those values (because they are still unspecified in the configuration).

![image](https://user-images.githubusercontent.com/2430490/82820743-5c447880-9e68-11ea-8139-2687f1fc04da.png)

## Testing plan

1. Importing an owners team on a Free organization should not panic.
1. Not specifying organization access in configuration (Teams plan) should still result in values returned from the API stored in state, and no changes should occur immediately doing another plan.

## Screenshots

Importing a Free plan Owners team (#179):
![image](https://user-images.githubusercontent.com/2430490/82822816-07a2fc80-9e6c-11ea-930d-1ff83f9af61d.png)

Creating a new team w/o Organization Access specified (computed values):
![image](https://user-images.githubusercontent.com/2430490/82823361-09b98b00-9e6d-11ea-84d2-8ddca553b3b5.png)

Specifying Organization Access:

![image](https://user-images.githubusercontent.com/2430490/82823544-64eb7d80-9e6d-11ea-9eef-984268a34530.png)
