### PR TITLE
tfe_team_access: Add Custom workspace access support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.19.0 (Unreleased)
+
+FEATURES:
+* r/tfe_team_access and d/tfe_team_access: Added support for custom workspace permissions ([#184](https://github.com/terraform-providers/terraform-provider-tfe/pull/184))
+
 BUG FIXES:
 * r/tfe_policy_set: Fixes issue when updating Policy Set branch attribute ([#185](https://github.com/terraform-providers/terraform-provider-tfe/pull/185))
+
 ## 0.18.1 (June 10, 2020)
 
 ENHANCEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-tfe
 
 require (
-	github.com/hashicorp/go-tfe v0.8.2
+	github.com/hashicorp/go-tfe v0.9.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
-github.com/hashicorp/go-tfe v0.8.2 h1:xuhz+tXIWS45BpVOpiI8SYppIbdcSuL7sAiEx6DHprw=
-github.com/hashicorp/go-tfe v0.8.2/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
+github.com/hashicorp/go-tfe v0.9.0 h1:M0cIzgzfQMvkeMfq6GkK8ZAqGdN4fA0tYNJ0BaX1m6s=
+github.com/hashicorp/go-tfe v0.9.0/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=

--- a/tfe/data_source_team_access.go
+++ b/tfe/data_source_team_access.go
@@ -17,6 +17,40 @@ func dataSourceTFETeamAccess() *schema.Resource {
 				Computed: true,
 			},
 
+			"permissions": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"runs": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"variables": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"state_versions": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"sentinel_mocks": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"workspace_locking": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"team_id": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/tfe/data_source_team_access_test.go
+++ b/tfe/data_source_team_access_test.go
@@ -21,6 +21,16 @@ func TestAccTFETeamAccessDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"data.tfe_team_access.foobar", "access", "write"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_access.foobar", "permissions.0.variables", "write"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_access.foobar", "permissions.0.state_versions", "write"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr(
+						"data.tfe_team_access.foobar", "permissions.0.workspace_locking", "true"),
 					resource.TestCheckResourceAttrSet("data.tfe_team_access.foobar", "id"),
 					resource.TestCheckResourceAttrSet("data.tfe_team_access.foobar", "team_id"),
 					resource.TestCheckResourceAttrSet("data.tfe_team_access.foobar", "workspace_id"),

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -60,6 +60,13 @@ func resourceTFETeamAccess() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+							AtLeastOneOf: []string{
+								"permissions.0.runs",
+								"permissions.0.variables",
+								"permissions.0.state_versions",
+								"permissions.0.sentinel_mocks",
+								"permissions.0.workspace_locking",
+							},
 							ValidateFunc: validation.StringInSlice(
 								[]string{
 									string(tfe.RunsPermissionRead),

--- a/tfe/resource_tfe_team_access.go
+++ b/tfe/resource_tfe_team_access.go
@@ -14,11 +14,13 @@ func resourceTFETeamAccess() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceTFETeamAccessCreate,
 		Read:   resourceTFETeamAccessRead,
+		Update: resourceTFETeamAccessUpdate,
 		Delete: resourceTFETeamAccessDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceTFETeamAccessImporter,
 		},
 
+		CustomizeDiff: setCustomOrComputedPermissions,
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
@@ -31,8 +33,11 @@ func resourceTFETeamAccess() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"access": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Optional: true,
+				Computed: true,
+				// This should be moved to the Resource level when possible:
+				// https://github.com/hashicorp/terraform-plugin-sdk/issues/470
+				ExactlyOneOf: []string{"access", "permissions"},
 				ValidateFunc: validation.StringInSlice(
 					[]string{
 						string(tfe.AccessAdmin),
@@ -42,6 +47,78 @@ func resourceTFETeamAccess() *schema.Resource {
 					},
 					false,
 				),
+			},
+
+			"permissions": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"runs": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.RunsPermissionRead),
+									string(tfe.RunsPermissionPlan),
+									string(tfe.RunsPermissionApply),
+								},
+								false,
+							),
+						},
+
+						"variables": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.VariablesPermissionNone),
+									string(tfe.VariablesPermissionRead),
+									string(tfe.VariablesPermissionWrite),
+								},
+								false,
+							),
+						},
+
+						"state_versions": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.StateVersionsPermissionNone),
+									string(tfe.StateVersionsPermissionReadOutputs),
+									string(tfe.StateVersionsPermissionRead),
+									string(tfe.StateVersionsPermissionWrite),
+								},
+								false,
+							),
+						},
+
+						"sentinel_mocks": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{
+									string(tfe.SentinelMocksPermissionNone),
+									string(tfe.SentinelMocksPermissionRead),
+								},
+								false,
+							),
+						},
+
+						"workspace_locking": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
 			},
 
 			"team_id": {
@@ -66,9 +143,8 @@ func resourceTFETeamAccess() *schema.Resource {
 func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error {
 	tfeClient := meta.(*tfe.Client)
 
-	// Get access and team ID.
+	// Get the access level
 	access := d.Get("access").(string)
-	teamID := d.Get("team_id").(string)
 
 	// Get the workspace
 	workspaceID := d.Get("workspace_id").(string)
@@ -79,6 +155,7 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Get the team.
+	teamID := d.Get("team_id").(string)
 	tm, err := tfeClient.Teams.Read(ctx, teamID)
 	if err != nil {
 		return fmt.Errorf("Error retrieving team %s: %v", teamID, err)
@@ -89,6 +166,36 @@ func resourceTFETeamAccessCreate(d *schema.ResourceData, meta interface{}) error
 		Access:    tfe.Access(tfe.AccessType(access)),
 		Team:      tm,
 		Workspace: ws,
+	}
+
+	if d.HasChange("permissions.0.runs") {
+		if v, ok := d.GetOk("permissions.0.runs"); ok {
+			options.Runs = tfe.RunsPermission(tfe.RunsPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.variables") {
+		if v, ok := d.GetOk("permissions.0.variables"); ok {
+			options.Variables = tfe.VariablesPermission(tfe.VariablesPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.state_versions") {
+		if v, ok := d.GetOk("permissions.0.state_versions"); ok {
+			options.StateVersions = tfe.StateVersionsPermission(tfe.StateVersionsPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.sentinel_mocks") {
+		if v, ok := d.GetOk("permissions.0.sentinel_mocks"); ok {
+			options.SentinelMocks = tfe.SentinelMocksPermission(tfe.SentinelMocksPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.workspace_locking") {
+		if v, ok := d.GetOkExists("permissions.0.workspace_locking"); ok {
+			options.WorkspaceLocking = tfe.Bool(v.(bool))
+		}
 	}
 
 	log.Printf("[DEBUG] Give team %s %s access to workspace: %s", tm.Name, access, ws.Name)
@@ -119,11 +226,83 @@ func resourceTFETeamAccessRead(d *schema.ResourceData, meta interface{}) error {
 
 	// Update config.
 	d.Set("access", string(tmAccess.Access))
+	permissions := []map[string]interface{}{{
+		"runs":              tmAccess.Runs,
+		"variables":         tmAccess.Variables,
+		"state_versions":    tmAccess.StateVersions,
+		"sentinel_mocks":    tmAccess.SentinelMocks,
+		"workspace_locking": tmAccess.WorkspaceLocking,
+	}}
+	if err := d.Set("permissions", permissions); err != nil {
+		return fmt.Errorf("error setting permissions for team access %s: %s", d.Id(), err)
+	}
 
 	if tmAccess.Team != nil {
 		d.Set("team_id", tmAccess.Team.ID)
 	} else {
 		d.Set("team_id", "")
+	}
+
+	return nil
+}
+
+func resourceTFETeamAccessUpdate(d *schema.ResourceData, meta interface{}) error {
+	tfeClient := meta.(*tfe.Client)
+
+	// create an options struct
+	options := tfe.TeamAccessUpdateOptions{}
+
+	// Set access level
+	access := d.Get("access").(string)
+	options.Access = tfe.Access(tfe.AccessType(access))
+
+	if d.HasChange("permissions.0.runs") {
+		if v, ok := d.GetOk("permissions.0.runs"); ok {
+			options.Runs = tfe.RunsPermission(tfe.RunsPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.variables") {
+		if v, ok := d.GetOk("permissions.0.variables"); ok {
+			options.Variables = tfe.VariablesPermission(tfe.VariablesPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.state_versions") {
+		if v, ok := d.GetOk("permissions.0.state_versions"); ok {
+			options.StateVersions = tfe.StateVersionsPermission(tfe.StateVersionsPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.sentinel_mocks") {
+		if v, ok := d.GetOk("permissions.0.sentinel_mocks"); ok {
+			options.SentinelMocks = tfe.SentinelMocksPermission(tfe.SentinelMocksPermissionType(v.(string)))
+		}
+	}
+
+	if d.HasChange("permissions.0.workspace_locking") {
+		if v, ok := d.GetOkExists("permissions.0.workspace_locking"); ok {
+			options.WorkspaceLocking = tfe.Bool(v.(bool))
+		}
+	}
+
+	log.Printf("[DEBUG] Update team access: %s", d.Id())
+	tmAccess, err := tfeClient.TeamAccess.Update(ctx, d.Id(), options)
+	if err != nil {
+		return fmt.Errorf(
+			"Error updating team access %s: %v", d.Id(), err)
+	}
+
+	// Update permissions, in the case that they were marked to be recomputed.
+	permissions := []map[string]interface{}{{
+		"runs":              tmAccess.Runs,
+		"variables":         tmAccess.Variables,
+		"state_versions":    tmAccess.StateVersions,
+		"sentinel_mocks":    tmAccess.SentinelMocks,
+		"workspace_locking": tmAccess.WorkspaceLocking,
+	}}
+	if err := d.Set("permissions", permissions); err != nil {
+		return fmt.Errorf("error setting permissions for team access %s: %s", d.Id(), err)
 	}
 
 	return nil
@@ -165,4 +344,34 @@ func resourceTFETeamAccessImporter(d *schema.ResourceData, meta interface{}) ([]
 	d.SetId(s[2])
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func setCustomOrComputedPermissions(d *schema.ResourceDiff, meta interface{}) error {
+	if _, ok := d.GetOk("access"); ok {
+		if d.HasChange("access") {
+			_, n := d.GetChange("access")
+			new := n.(string)
+
+			if new != "custom" {
+				// If access is being changed to an explicit value, and access is NOT 'custom', all permissions
+				// will be read-only and computed by the API.
+				d.SetNewComputed("permissions")
+			}
+		} else {
+			// If access is present, not being explicitly changed, but permissions are being changed, the user is switching
+			// from using a fixed access level (read/plan/write/apply) to a permissions block ('custom' access)
+			// Set the access to custom.
+			if d.HasChange("permissions.0") {
+				d.SetNew("access", tfe.AccessCustom)
+			}
+		}
+	} else {
+		// If there's no access set, we must be creating a new resource with
+		// a permissions block. Set the access to custom.
+		if _, ok := d.GetOk("permissions"); ok {
+			d.SetNew("access", tfe.AccessCustom)
+		}
+	}
+
+	return nil
 }

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -9,7 +9,41 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccTFETeamAccess_basic(t *testing.T) {
+func TestAccTFETeamAccess_write(t *testing.T) {
+	tmAccess := &tfe.TeamAccess{}
+	expectedPermissions := map[string]interface{}{
+		"runs":              tfe.RunsPermissionApply,
+		"variables":         tfe.VariablesPermissionWrite,
+		"state_versions":    tfe.StateVersionsPermissionWrite,
+		"sentinel_mocks":    tfe.SentinelMocksPermissionRead,
+		"workspace_locking": true,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamAccess_write,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessWrite),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(tmAccess, expectedPermissions),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFETeamAccess_custom(t *testing.T) {
 	tmAccess := &tfe.TeamAccess{}
 
 	resource.Test(t, resource.TestCase{
@@ -18,13 +52,147 @@ func TestAccTFETeamAccess_basic(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_basic,
+				Config: testAccTFETeamAccess_custom,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTFETeamAccessExists(
 						"tfe_team_access.foobar", tmAccess),
-					testAccCheckTFETeamAccessAttributes(tmAccess),
-					resource.TestCheckResourceAttr(
-						"tfe_team_access.foobar", "access", "write"),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessCustom),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(
+						tmAccess,
+						map[string]interface{}{
+							"runs":              tfe.RunsPermissionApply,
+							"variables":         tfe.VariablesPermissionNone,
+							"state_versions":    tfe.StateVersionsPermissionReadOutputs,
+							"sentinel_mocks":    tfe.SentinelMocksPermissionNone,
+							"workspace_locking": false,
+						},
+					),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read-outputs"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
+	tmAccess := &tfe.TeamAccess{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamAccess_write,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessWrite),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(
+						tmAccess,
+						map[string]interface{}{
+							"runs":              tfe.RunsPermissionApply,
+							"variables":         tfe.VariablesPermissionWrite,
+							"state_versions":    tfe.StateVersionsPermissionWrite,
+							"sentinel_mocks":    tfe.SentinelMocksPermissionRead,
+							"workspace_locking": true,
+						},
+					),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "true"),
+				),
+			},
+			{
+				Config: testAccTFETeamAccess_custom,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessCustom),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(
+						tmAccess,
+						map[string]interface{}{
+							"runs":              tfe.RunsPermissionApply,
+							"variables":         tfe.VariablesPermissionWrite,
+							"state_versions":    tfe.StateVersionsPermissionReadOutputs,
+							"sentinel_mocks":    tfe.SentinelMocksPermissionRead,
+							"workspace_locking": false,
+						},
+					),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read-outputs"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
+	tmAccess := &tfe.TeamAccess{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFETeamAccessDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFETeamAccess_custom,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessCustom),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(
+						tmAccess,
+						map[string]interface{}{
+							"runs":              tfe.RunsPermissionApply,
+							"variables":         tfe.VariablesPermissionNone,
+							"state_versions":    tfe.StateVersionsPermissionReadOutputs,
+							"sentinel_mocks":    tfe.SentinelMocksPermissionNone,
+							"workspace_locking": false,
+						},
+					),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read-outputs"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
+				),
+			},
+			{
+				Config: testAccTFETeamAccess_plan,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFETeamAccessExists(
+						"tfe_team_access.foobar", tmAccess),
+					testAccCheckTFETeamAccessAttributesAccessIs(tmAccess, tfe.AccessPlan),
+					testAccCheckTFETeamAccessAttributesPermissionsAre(
+						tmAccess,
+						map[string]interface{}{
+							"runs":              tfe.RunsPermissionPlan,
+							"variables":         tfe.VariablesPermissionRead,
+							"state_versions":    tfe.StateVersionsPermissionRead,
+							"sentinel_mocks":    tfe.SentinelMocksPermissionNone,
+							"workspace_locking": false,
+						},
+					),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "plan"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "plan"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
 				),
 			},
 		},
@@ -38,7 +206,7 @@ func TestAccTFETeamAccess_import(t *testing.T) {
 		CheckDestroy: testAccCheckTFETeamAccessDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTFETeamAccess_basic,
+				Config: testAccTFETeamAccess_write,
 			},
 
 			{
@@ -80,11 +248,31 @@ func testAccCheckTFETeamAccessExists(
 	}
 }
 
-func testAccCheckTFETeamAccessAttributes(
-	tmAccess *tfe.TeamAccess) resource.TestCheckFunc {
+func testAccCheckTFETeamAccessAttributesAccessIs(tmAccess *tfe.TeamAccess, access tfe.AccessType) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if tmAccess.Access != tfe.AccessWrite {
+		if tmAccess.Access != access {
 			return fmt.Errorf("Bad access: %s", tmAccess.Access)
+		}
+		return nil
+	}
+}
+
+func testAccCheckTFETeamAccessAttributesPermissionsAre(tmAccess *tfe.TeamAccess, expectedPermissions map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if tmAccess.Runs != expectedPermissions["runs"].(tfe.RunsPermissionType) {
+			return fmt.Errorf("Bad runs permission: Expected %s, Received %s", expectedPermissions["runs"], tmAccess.Runs)
+		}
+		if tmAccess.Variables != expectedPermissions["variables"].(tfe.VariablesPermissionType) {
+			return fmt.Errorf("Bad variables permission: Expected %s, Received %s", expectedPermissions["variables"], tmAccess.Variables)
+		}
+		if tmAccess.StateVersions != expectedPermissions["state_versions"].(tfe.StateVersionsPermissionType) {
+			return fmt.Errorf("Bad state-versions permission: Expected %s, Received %s", expectedPermissions["state_versions"], tmAccess.StateVersions)
+		}
+		if tmAccess.SentinelMocks != expectedPermissions["sentinel_mocks"].(tfe.SentinelMocksPermissionType) {
+			return fmt.Errorf("Bad sentinel-mocks permission: Expected %s, Received %s", expectedPermissions["sentinel_mocks"], tmAccess.SentinelMocks)
+		}
+		if tmAccess.WorkspaceLocking != expectedPermissions["workspace_locking"].(bool) {
+			return fmt.Errorf("Bad workspace-locking permission: Expected %s, Received %t", expectedPermissions["workspace_locking"], tmAccess.WorkspaceLocking)
 		}
 		return nil
 	}
@@ -111,7 +299,7 @@ func testAccCheckTFETeamAccessDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccTFETeamAccess_basic = `
+const testAccTFETeamAccess_write = `
 resource "tfe_organization" "foobar" {
   name  = "tst-terraform"
   email = "admin@company.com"
@@ -129,6 +317,54 @@ resource "tfe_workspace" "foobar" {
 
 resource "tfe_team_access" "foobar" {
   access       = "write"
+  team_id      = "${tfe_team.foobar.id}"
+  workspace_id = "${tfe_workspace.foobar.id}"
+}`
+
+const testAccTFETeamAccess_plan = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar" {
+  name         = "team-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_team_access" "foobar" {
+  access       = "plan"
+  team_id      = "${tfe_team.foobar.id}"
+  workspace_id = "${tfe_workspace.foobar.id}"
+}`
+
+const testAccTFETeamAccess_custom = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_team" "foobar" {
+  name         = "team-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_workspace" "foobar" {
+  name         = "workspace-test"
+  organization = "${tfe_organization.foobar.id}"
+}
+
+resource "tfe_team_access" "foobar" {
+  permissions {
+    runs = "apply"
+    state_versions = "read-outputs"
+    workspace_locking = false
+  }
   team_id      = "${tfe_team.foobar.id}"
   workspace_id = "${tfe_workspace.foobar.id}"
 }`

--- a/tfe/resource_tfe_team_access_test.go
+++ b/tfe/resource_tfe_team_access_test.go
@@ -61,7 +61,7 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 						tmAccess,
 						map[string]interface{}{
 							"runs":              tfe.RunsPermissionApply,
-							"variables":         tfe.VariablesPermissionNone,
+							"variables":         tfe.VariablesPermissionRead,
 							"state_versions":    tfe.StateVersionsPermissionReadOutputs,
 							"sentinel_mocks":    tfe.SentinelMocksPermissionNone,
 							"workspace_locking": false,
@@ -69,7 +69,7 @@ func TestAccTFETeamAccess_custom(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
-					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "read"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read-outputs"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
@@ -121,17 +121,17 @@ func TestAccTFETeamAccess_updateToCustom(t *testing.T) {
 						tmAccess,
 						map[string]interface{}{
 							"runs":              tfe.RunsPermissionApply,
-							"variables":         tfe.VariablesPermissionWrite,
+							"variables":         tfe.VariablesPermissionRead,
 							"state_versions":    tfe.StateVersionsPermissionReadOutputs,
-							"sentinel_mocks":    tfe.SentinelMocksPermissionRead,
+							"sentinel_mocks":    tfe.SentinelMocksPermissionNone,
 							"workspace_locking": false,
 						},
 					),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
-					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "write"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "read"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read-outputs"),
-					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "read"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
 				),
 			},
@@ -157,7 +157,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 						tmAccess,
 						map[string]interface{}{
 							"runs":              tfe.RunsPermissionApply,
-							"variables":         tfe.VariablesPermissionNone,
+							"variables":         tfe.VariablesPermissionRead,
 							"state_versions":    tfe.StateVersionsPermissionReadOutputs,
 							"sentinel_mocks":    tfe.SentinelMocksPermissionNone,
 							"workspace_locking": false,
@@ -165,7 +165,7 @@ func TestAccTFETeamAccess_updateFromCustom(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "access", "custom"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.runs", "apply"),
-					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "none"),
+					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.variables", "read"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.state_versions", "read-outputs"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.sentinel_mocks", "none"),
 					resource.TestCheckResourceAttr("tfe_team_access.foobar", "permissions.0.workspace_locking", "false"),
@@ -362,7 +362,9 @@ resource "tfe_workspace" "foobar" {
 resource "tfe_team_access" "foobar" {
   permissions {
     runs = "apply"
+    variables = "read"
     state_versions = "read-outputs"
+    sentinel_mocks = "none"
     workspace_locking = false
   }
   team_id      = "${tfe_team.foobar.id}"

--- a/vendor/github.com/hashicorp/go-tfe/team_access.go
+++ b/vendor/github.com/hashicorp/go-tfe/team_access.go
@@ -25,6 +25,9 @@ type TeamAccesses interface {
 	// Read a team access by its ID.
 	Read(ctx context.Context, teamAccessID string) (*TeamAccess, error)
 
+	// Update a team access by its ID.
+	Update(ctx context.Context, teamAccessID string, options TeamAccessUpdateOptions) (*TeamAccess, error)
+
 	// Remove team access from a workspace.
 	Remove(ctx context.Context, teamAccessID string) error
 }
@@ -37,12 +40,44 @@ type teamAccesses struct {
 // AccessType represents a team access type.
 type AccessType string
 
-// List all available team access types.
+// RunsPermissionType represents the permissiontype to a workspace's runs.
+type RunsPermissionType string
+
+// VariablesPermissionType represents the permissiontype to a workspace's variables.
+type VariablesPermissionType string
+
+// StateVersionsPermissionType represents the permissiontype to a workspace's state versions.
+type StateVersionsPermissionType string
+
+// SentinelMocksPermissionType represents the permissiontype to a workspace's Sentinel mocks.
+type SentinelMocksPermissionType string
+
+// WorkspaceLockingPermissionType represents the permissiontype to lock or unlock a workspace.
+type WorkspaceLockingPermissionType bool
+
+// List all available team access types and permissions.
 const (
-	AccessAdmin AccessType = "admin"
-	AccessPlan  AccessType = "plan"
-	AccessRead  AccessType = "read"
-	AccessWrite AccessType = "write"
+	AccessAdmin  AccessType = "admin"
+	AccessPlan   AccessType = "plan"
+	AccessRead   AccessType = "read"
+	AccessWrite  AccessType = "write"
+	AccessCustom AccessType = "custom"
+
+	RunsPermissionRead  RunsPermissionType = "read"
+	RunsPermissionPlan  RunsPermissionType = "plan"
+	RunsPermissionApply RunsPermissionType = "apply"
+
+	VariablesPermissionNone  VariablesPermissionType = "none"
+	VariablesPermissionRead  VariablesPermissionType = "read"
+	VariablesPermissionWrite VariablesPermissionType = "write"
+
+	StateVersionsPermissionNone        StateVersionsPermissionType = "none"
+	StateVersionsPermissionReadOutputs StateVersionsPermissionType = "read-outputs"
+	StateVersionsPermissionRead        StateVersionsPermissionType = "read"
+	StateVersionsPermissionWrite       StateVersionsPermissionType = "write"
+
+	SentinelMocksPermissionNone SentinelMocksPermissionType = "none"
+	SentinelMocksPermissionRead SentinelMocksPermissionType = "read"
 )
 
 // TeamAccessList represents a list of team accesses.
@@ -53,8 +88,13 @@ type TeamAccessList struct {
 
 // TeamAccess represents the workspace access for a team.
 type TeamAccess struct {
-	ID     string     `jsonapi:"primary,team-workspaces"`
-	Access AccessType `jsonapi:"attr,access"`
+	ID               string                      `jsonapi:"primary,team-workspaces"`
+	Access           AccessType                  `jsonapi:"attr,access"`
+	Runs             RunsPermissionType          `jsonapi:"attr,runs"`
+	Variables        VariablesPermissionType     `jsonapi:"attr,variables"`
+	StateVersions    StateVersionsPermissionType `jsonapi:"attr,state-versions"`
+	SentinelMocks    SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks"`
+	WorkspaceLocking bool                        `jsonapi:"attr,workspace-locking"`
 
 	// Relations
 	Team      *Team      `jsonapi:"relation,team"`
@@ -104,6 +144,14 @@ type TeamAccessAddOptions struct {
 
 	// The type of access to grant.
 	Access *AccessType `jsonapi:"attr,access"`
+
+	// Custom workspace access permissions. These can only be edited when Access is 'custom'; otherwise, they are
+	// read-only and reflect the Access level's implicit permissions.
+	Runs             *RunsPermissionType          `jsonapi:"attr,runs,omitempty"`
+	Variables        *VariablesPermissionType     `jsonapi:"attr,variables,omitempty"`
+	StateVersions    *StateVersionsPermissionType `jsonapi:"attr,state-versions,omitempty"`
+	SentinelMocks    *SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks,omitempty"`
+	WorkspaceLocking *bool                        `jsonapi:"attr,workspace-locking,omitempty"`
 
 	// The team to add to the workspace
 	Team *Team `jsonapi:"relation,team"`
@@ -167,6 +215,47 @@ func (s *teamAccesses) Read(ctx context.Context, teamAccessID string) (*TeamAcce
 	}
 
 	return ta, nil
+}
+
+// TeamAccessUpdateOptions represents the options for updating team access.
+type TeamAccessUpdateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,team-workspaces"`
+
+	// The type of access to grant.
+	Access *AccessType `jsonapi:"attr,access,omitempty"`
+
+	// Custom workspace access permissions. These can only be edited when Access is 'custom'; otherwise, they are
+	// read-only and reflect the Access level's implicit permissions.
+	Runs             *RunsPermissionType          `jsonapi:"attr,runs,omitempty"`
+	Variables        *VariablesPermissionType     `jsonapi:"attr,variables,omitempty"`
+	StateVersions    *StateVersionsPermissionType `jsonapi:"attr,state-versions,omitempty"`
+	SentinelMocks    *SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks,omitempty"`
+	WorkspaceLocking *bool                        `jsonapi:"attr,workspace-locking,omitempty"`
+}
+
+// Update team access for a workspace
+func (s *teamAccesses) Update(ctx context.Context, teamAccessID string, options TeamAccessUpdateOptions) (*TeamAccess, error) {
+	if !validStringID(&teamAccessID) {
+		return nil, errors.New("invalid value for team access ID")
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ta := &TeamAccess{}
+	err = s.client.do(ctx, req, ta)
+	if err != nil {
+		return nil, err
+	}
+
+	return ta, err
 }
 
 // Remove team access from a workspace.

--- a/vendor/github.com/hashicorp/go-tfe/type_helpers.go
+++ b/vendor/github.com/hashicorp/go-tfe/type_helpers.go
@@ -5,6 +5,26 @@ func Access(v AccessType) *AccessType {
 	return &v
 }
 
+// RunsPermission returns a pointer to the given team runs permission type.
+func RunsPermission(v RunsPermissionType) *RunsPermissionType {
+	return &v
+}
+
+// VariablesPermission returns a pointer to the given team variables permission type.
+func VariablesPermission(v VariablesPermissionType) *VariablesPermissionType {
+	return &v
+}
+
+// StateVersionsPermission returns a pointer to the given team state versions permission type.
+func StateVersionsPermission(v StateVersionsPermissionType) *StateVersionsPermissionType {
+	return &v
+}
+
+// SentinelMocksPermission returns a pointer to the given team Sentinel mocks permission type.
+func SentinelMocksPermission(v SentinelMocksPermissionType) *SentinelMocksPermissionType {
+	return &v
+}
+
 // AuthPolicy returns a pointer to the given authentication poliy.
 func AuthPolicy(v AuthPolicyType) *AuthPolicyType {
 	return &v

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,7 +99,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.4.1
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.8.2
+# github.com/hashicorp/go-tfe v0.9.0
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid

--- a/website/docs/d/team_access.html.markdown
+++ b/website/docs/d/team_access.html.markdown
@@ -31,4 +31,9 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` The team access ID.
-* `access` - The type of access granted.
+* `access` - The type of access granted to the team on the workspace.
+* `permissions.0.runs` - The permission granted to runs. Valid values are `read`, `plan`, or `apply`
+* `permissions.0.variables` - The permissions granted to variables. Valid values are `none`, `read`, or `write`
+* `permissions.0.state_versions` - The permissions granted to state versions. Valid values are `none`, `read-outputs`, `read`, or `write`
+* `permissions.0.sentinel_mocks` - The permissions granted to Sentinel mocks. Valid values are `none` or `read`
+* `permissions.0.workspace_locking` - Whether permission is granted to manually lock the workspace or not.

--- a/website/docs/d/team_access.html.markdown
+++ b/website/docs/d/team_access.html.markdown
@@ -32,8 +32,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` The team access ID.
 * `access` - The type of access granted to the team on the workspace.
-* `permissions.0.runs` - The permission granted to runs. Valid values are `read`, `plan`, or `apply`
-* `permissions.0.variables` - The permissions granted to variables. Valid values are `none`, `read`, or `write`
-* `permissions.0.state_versions` - The permissions granted to state versions. Valid values are `none`, `read-outputs`, `read`, or `write`
-* `permissions.0.sentinel_mocks` - The permissions granted to Sentinel mocks. Valid values are `none` or `read`
-* `permissions.0.workspace_locking` - Whether permission is granted to manually lock the workspace or not.
+* `permissions` - The permissions granted to the team on the workspaces for each whatever.
+
+The `permissions` block contains:
+
+* `runs` - The permission granted to runs. Valid values are `read`, `plan`, or `apply`
+* `variables` - The permissions granted to variables. Valid values are `none`, `read`, or `write`
+* `state_versions` - The permissions granted to state versions. Valid values are `none`, `read-outputs`, `read`, or `write`
+* `sentinel_mocks` - The permissions granted to Sentinel mocks. Valid values are `none` or `read`
+* `workspace_locking` - Whether permission is granted to manually lock the workspace or not.

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -38,18 +38,18 @@ The following arguments are supported:
 
 * `team_id` - (Required) ID of the team to add to the workspace.
 * `workspace_id` - (Required) ID of the workspace to which the team will be added.
-* `access` - (Conflicts with `permissions`) Type of fixed access to grant. Valid values are `admin`, `read`, `plan`, or `write`. To use `custom` permissions, use a `permissions` block instead.
-* `permissions` - (Conflicts with `access`) Permissions to grant using [custom workspace permissions](https://www.terraform.io/docs/cloud/users-teams-organizations/permissions.html#custom-workspace-permissions).
+* `access` - (Optional) Type of fixed access to grant. Valid values are `admin`, `read`, `plan`, or `write`. To use `custom` permissions, use a `permissions` block instead. This value _must not_ be provided if `permissions` is provided.
+* `permissions` - (Optional) Permissions to grant using [custom workspace permissions](https://www.terraform.io/docs/cloud/users-teams-organizations/permissions.html#custom-workspace-permissions). This value _must not_ be provided if `access` is provided.
 
-  The arguments for this block are:
+The `permissions` block supports:
 
-  - `runs` - (Required) The permission to grant the team on the workspace's runs. Valid values are `read`, `plan`, or `apply`.
-  - `variables` - (Required) The permission to grant the team on the workspace's variables. Valid values are `none`, `read`, or `write`.
-  - `state_versions` - (Required) The permission to grant the team on the workspace's state versions. Valid values are `none`, `read`, `read-outputs`, or `write`.
-  - `sentinel_mocks` - (Required) The permission to grant the team on the workspace's generated Sentinel mocks, Valid values are `none` or `read`.
-  - `workspace_locking` - (Required) Boolean determining whether or not to grant the team permission to manually lock/unlock the workspace.
+* `runs` - (Required) The permission to grant the team on the workspace's runs. Valid values are `read`, `plan`, or `apply`.
+* `variables` - (Required) The permission to grant the team on the workspace's variables. Valid values are `none`, `read`, or `write`.
+* `state_versions` - (Required) The permission to grant the team on the workspace's state versions. Valid values are `none`, `read`, `read-outputs`, or `write`.
+* `sentinel_mocks` - (Required) The permission to grant the team on the workspace's generated Sentinel mocks, Valid values are `none` or `read`.
+* `workspace_locking` - (Required) Boolean determining whether or not to grant the team permission to manually lock/unlock the workspace.
 
-At least one of `access` or `permissions` must be specified, but not both. Whichever is omitted will automatically reflect the state of the other.
+-> **Note:** At least one of `access` or `permissions` _must_ be provided, but not both. Whichever is omitted will automatically reflect the state of the other.
 
 ## Attributes Reference
 

--- a/website/docs/r/team_access.html.markdown
+++ b/website/docs/r/team_access.html.markdown
@@ -36,10 +36,20 @@ resource "tfe_team_access" "test" {
 
 The following arguments are supported:
 
-* `access` - (Required) Type of access to grant. Valid values are `admin`,
-  `read`, `plan`, or `write`.
 * `team_id` - (Required) ID of the team to add to the workspace.
 * `workspace_id` - (Required) ID of the workspace to which the team will be added.
+* `access` - (Conflicts with `permissions`) Type of fixed access to grant. Valid values are `admin`, `read`, `plan`, or `write`. To use `custom` permissions, use a `permissions` block instead.
+* `permissions` - (Conflicts with `access`) Permissions to grant using [custom workspace permissions](https://www.terraform.io/docs/cloud/users-teams-organizations/permissions.html#custom-workspace-permissions).
+
+  The arguments for this block are:
+
+  - `runs` - (Required) The permission to grant the team on the workspace's runs. Valid values are `read`, `plan`, or `apply`.
+  - `variables` - (Required) The permission to grant the team on the workspace's variables. Valid values are `none`, `read`, or `write`.
+  - `state_versions` - (Required) The permission to grant the team on the workspace's state versions. Valid values are `none`, `read`, `read-outputs`, or `write`.
+  - `sentinel_mocks` - (Required) The permission to grant the team on the workspace's generated Sentinel mocks, Valid values are `none` or `read`.
+  - `workspace_locking` - (Required) Boolean determining whether or not to grant the team permission to manually lock/unlock the workspace.
+
+At least one of `access` or `permissions` must be specified, but not both. Whichever is omitted will automatically reflect the state of the other.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

- [x] **Requires a go-tfe release with https://github.com/hashicorp/go-tfe/pull/123**

These changes contain:

* Added support for Custom workspace access in the [Team Access API](https://www.terraform.io/docs/cloud/api/team-access.html).
* In-place updating of Team Accesses rather than always ForceNew behavior

The new API behavior is tough to model because of a number of limitations within the provider SDK, such as:

* Schema validations are limited to the single attribute they are defined on; you cannot validate something with the additional context of another attribute's value in the resource.
* The SDK cannot discern between something defined _only_ in state, or _only_ in configuration. Some assumptions can be made (and are made in these changes) via GetChange(), but it's hacky at best.

After a few different iterations attempting to conditionally allow a user to edit custom permissions only when access is set to custom, the core of this design is to place custom access within a new `permissions` block which is validated at the schema level to conflict with `access`; `custom` access itself and the read-only aspect of them when `access` is not custom is then handled by plan-time deductions with `CustomizeDiff`.

A huge thank you to Martin Atkins (@apparentlymart) for all the time spent assisting me on getting this right ❤️ 

## Testing plan

* Use `tfe_team_access` resource to manage [Team Access](https://www.terraform.io/docs/cloud/api/team-access.html). Honestly, just try and break it. Maybe output the data source to make sure that works, as well.

## Output from acceptance tests

```
» TESTARGS="-run TestAccTFETeamAccess" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFETeamAccess -timeout 15m
?       github.com/terraform-providers/terraform-provider-tfe   [no test files]
=== RUN   TestAccTFETeamAccessDataSource_basic
--- PASS: TestAccTFETeamAccessDataSource_basic (10.83s)
=== RUN   TestAccTFETeamAccess_write
--- PASS: TestAccTFETeamAccess_write (8.13s)
=== RUN   TestAccTFETeamAccess_custom
--- PASS: TestAccTFETeamAccess_custom (9.81s)
=== RUN   TestAccTFETeamAccess_updateToCustom
--- PASS: TestAccTFETeamAccess_updateToCustom (12.87s)
=== RUN   TestAccTFETeamAccess_updateFromCustom
--- PASS: TestAccTFETeamAccess_updateFromCustom (13.10s)
=== RUN   TestAccTFETeamAccess_import
--- PASS: TestAccTFETeamAccess_import (9.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-tfe/tfe       64.374s
```
## Behavior walkthrough

Creating a new team access with standard Write access:

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/2430490/84700096-39adf880-af18-11ea-9a65-3d2ac591adca.png">

Creating a new team access with standard Write access (not available at plan time):

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/2430490/84700371-ab864200-af18-11ea-9e7f-09714e988069.png">

Creating a new team access with Custom access:

<img width="1229" alt="image" src="https://user-images.githubusercontent.com/2430490/84700647-264f5d00-af19-11ea-8228-492e3b0da400.png">

Creating a new team access with Custom access (not available at plan time):

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/2430490/84700816-7af2d800-af19-11ea-80e8-1e498117e5b9.png">

Updating access from a standard level (write) to custom access:

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/2430490/84701058-e341b980-af19-11ea-9fe8-556e1b2ffbe0.png">

Updating access from custom to standard access:

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/2430490/84701287-51867c00-af1a-11ea-9ba0-01d7315c4f6d.png">

Updating access from custom to standard access (not available at plan time):

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/2430490/84701192-2865eb80-af1a-11ea-8fdd-4e28789aa245.png">
