### PR TITLE
Fix broken Travis CI tests

### DIFF
--- a/tfe/resource_tfe_registry_module_test.go
+++ b/tfe/resource_tfe_registry_module_test.go
@@ -194,13 +194,22 @@ func testAccPreCheckTFERegistryModule(t *testing.T) {
 }
 
 func getRegistryModuleRepository() string {
+	if GITHUB_REGISTRY_MODULE_IDENTIFIER == "" {
+		return GITHUB_REGISTRY_MODULE_IDENTIFIER
+	}
 	return strings.Split(GITHUB_REGISTRY_MODULE_IDENTIFIER, "/")[1]
 }
 func getRegistryModuleName() string {
+	if GITHUB_REGISTRY_MODULE_IDENTIFIER == "" {
+		return GITHUB_REGISTRY_MODULE_IDENTIFIER
+	}
 	return strings.SplitN(getRegistryModuleRepository(), "-", 3)[2]
 }
 
 func getRegistryModuleProvider() string {
+	if GITHUB_REGISTRY_MODULE_IDENTIFIER == "" {
+		return GITHUB_REGISTRY_MODULE_IDENTIFIER
+	}
 	return strings.SplitN(getRegistryModuleRepository(), "-", 3)[1]
 }
 


### PR DESCRIPTION
## Description

The Travis CI tests are breaking because they don't seem to be respecting my original check for this environment variable so I'm adding it to the functions themselves. 

## Testing plan

Just see if the tests pass