### PR TITLE
fix missing sidebar links

### DIFF
--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -13,6 +13,10 @@
                 <li<%= sidebar_current("docs-tfe-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-datasource-tfe-organization-membership") %>>
+                            <a href="/docs/providers/tfe/d/organization_membership.html">tfe_organization_membership</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-datasource-tfe-ssh-key") %>>
                             <a href="/docs/providers/tfe/d/ssh_key.html">tfe_ssh_key</a>
                         </li>
@@ -65,6 +69,10 @@
                             <a href="/docs/providers/tfe/r/policy_set_parameter.html">tfe_policy_set_parameter</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-resource-tfe-registry-module") %>>
+                            <a href="/docs/providers/tfe/r/registry_module.html">tfe_registry_module</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-resource-tfe-run-trigger") %>>
                             <a href="/docs/providers/tfe/r/run_trigger.html">tfe_run_trigger</a>
                         </li>
@@ -85,16 +93,16 @@
                             <a href="/docs/providers/tfe/r/team_access.html">tfe_team_access</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-resource-tfe-team-organization-member") %>>
-                            <a href="/docs/providers/tfe/r/team_organization_member.html">tfe_team_organization_member</a>
-                        </li>
-
                         <li<%= sidebar_current("docs-resource-tfe-team-member-x") %>>
                             <a href="/docs/providers/tfe/r/team_member.html">tfe_team_member</a>
                         </li>
 
                         <li<%= sidebar_current("docs-resource-tfe-team-members") %>>
                             <a href="/docs/providers/tfe/r/team_members.html">tfe_team_members</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-resource-tfe-team-organization-member") %>>
+                            <a href="/docs/providers/tfe/r/team_organization_member.html">tfe_team_organization_member</a>
                         </li>
 
                         <li<%= sidebar_current("docs-resource-tfe-team-token") %>>


### PR DESCRIPTION
## Description

I noticed we have a couple of links missing from the sidebar in the docs hosted at [terraform.io](https://www.terraform.io/docs/providers/tfe/index.html) - this PR makes the terraform.io sidebar nav consistent with the [registry.terraform.io sidebar nav](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs).

**NOTE**: this commit will need to be cherry-picked to the `stable-website` branch after merge.

## Testing plan

1. Pull down the [terraform-website](https://github.com/hashicorp/terraform-website) repo and follow [the directions for previewing provider changes](https://github.com/hashicorp/terraform-website#previewing-changes-from-providers-or-terraform-core).
1. Navigate to the tfe provider docs and verify that the sidebar contains the previously missing links.

## External links

- [tfe provider docs on terraform.io](https://www.terraform.io/docs/providers/tfe/index.html)
- [tfe provider docs on registry.terraform.io](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs)