### PR TITLE
Add speculative_enabled argument to tfe_workspace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-tfe
 
 require (
-	github.com/hashicorp/go-tfe v0.10.0
+	github.com/hashicorp/go-tfe v0.10.2
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
-github.com/hashicorp/go-tfe v0.10.0 h1:gn1rgV/laCeqSMRtcOS2eictemN3lUy/o/dCCq0H9Qo=
-github.com/hashicorp/go-tfe v0.10.0/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
+github.com/hashicorp/go-tfe v0.10.2 h1:nYYlk0B0ku9cyuU9JHvpVd21whpwWfGiRf05VV9jdAY=
+github.com/hashicorp/go-tfe v0.10.2/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnOn8E8stHc=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=

--- a/tfe/data_source_workspace.go
+++ b/tfe/data_source_workspace.go
@@ -43,6 +43,11 @@ func dataSourceTFEWorkspace() *schema.Resource {
 				Computed: true,
 			},
 
+			"speculative_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"ssh_key_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -116,6 +121,7 @@ func dataSourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("file_triggers_enabled", workspace.FileTriggersEnabled)
 	d.Set("operations", workspace.Operations)
 	d.Set("queue_all_runs", workspace.QueueAllRuns)
+	d.Set("speculative_enabled", workspace.SpeculativeEnabled)
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)

--- a/tfe/data_source_workspace_test.go
+++ b/tfe/data_source_workspace_test.go
@@ -31,6 +31,8 @@ func TestAccTFEWorkspaceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "queue_all_runs", "false"),
 					resource.TestCheckResourceAttr(
+						"data.tfe_workspace.foobar", "speculative_enabled", "true"),
+					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "terraform_version", "0.11.1"),
 					resource.TestCheckResourceAttr(
 						"data.tfe_workspace.foobar", "trigger_prefixes.#", "2"),
@@ -61,6 +63,7 @@ resource "tfe_workspace" "foobar" {
   auto_apply            = true
   file_triggers_enabled = true
   queue_all_runs        = false
+  speculative_enabled   = true
   terraform_version     = "0.11.1"
   trigger_prefixes      = ["/modules", "/shared"]
   working_directory     = "terraform/test"

--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -66,6 +66,12 @@ func resourceTFEWorkspace() *schema.Resource {
 				Default:  true,
 			},
 
+			"speculative_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"ssh_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -143,6 +149,7 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 		FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 		Operations:          tfe.Bool(d.Get("operations").(bool)),
 		QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
+		SpeculativeEnabled:  tfe.Bool(d.Get("speculative_enabled").(bool)),
 		WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 	}
 
@@ -215,6 +222,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("file_triggers_enabled", workspace.FileTriggersEnabled)
 	d.Set("operations", workspace.Operations)
 	d.Set("queue_all_runs", workspace.QueueAllRuns)
+	d.Set("speculative_enabled", workspace.SpeculativeEnabled)
 	d.Set("terraform_version", workspace.TerraformVersion)
 	d.Set("trigger_prefixes", workspace.TriggerPrefixes)
 	d.Set("working_directory", workspace.WorkingDirectory)
@@ -260,7 +268,7 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 	if d.HasChange("name") || d.HasChange("auto_apply") || d.HasChange("queue_all_runs") ||
 		d.HasChange("terraform_version") || d.HasChange("working_directory") || d.HasChange("vcs_repo") ||
 		d.HasChange("file_triggers_enabled") || d.HasChange("trigger_prefixes") ||
-		d.HasChange("operations") {
+		d.HasChange("operations") || d.HasChange("speculative_enabled") {
 		// Create a new options struct.
 		options := tfe.WorkspaceUpdateOptions{
 			Name:                tfe.String(d.Get("name").(string)),
@@ -268,6 +276,7 @@ func resourceTFEWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error 
 			FileTriggersEnabled: tfe.Bool(d.Get("file_triggers_enabled").(bool)),
 			Operations:          tfe.Bool(d.Get("operations").(bool)),
 			QueueAllRuns:        tfe.Bool(d.Get("queue_all_runs").(bool)),
+			SpeculativeEnabled:  tfe.Bool(d.Get("speculative_enabled").(bool)),
 			WorkingDirectory:    tfe.String(d.Get("working_directory").(string)),
 		}
 

--- a/tfe/resource_tfe_workspace_test.go
+++ b/tfe/resource_tfe_workspace_test.go
@@ -37,6 +37,8 @@ func TestAccTFEWorkspace_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "queue_all_runs", "true"),
 					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "speculative_enabled", "true"),
+					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "working_directory", ""),
@@ -323,6 +325,37 @@ func TestAccTFEWorkspace_updateTriggerPrefixes(t *testing.T) {
 					testAccCheckTFEWorkspaceAttributes(workspace),
 					resource.TestCheckResourceAttr(
 						"tfe_workspace.foobar", "trigger_prefixes.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTFEWorkspace_updateSpeculative(t *testing.T) {
+	workspace := &tfe.Workspace{}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTFEWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEWorkspace_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "speculative_enabled", "true"),
+				),
+			},
+
+			{
+				Config: testAccTFEWorkspace_basicSpeculativeOff,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTFEWorkspaceExists(
+						"tfe_workspace.foobar", workspace),
+					resource.TestCheckResourceAttr(
+						"tfe_workspace.foobar", "speculative_enabled", "false"),
 				),
 			},
 		},
@@ -799,6 +832,19 @@ resource "tfe_workspace" "foobar" {
   organization          = "${tfe_organization.foobar.id}"
   auto_apply            = true
   file_triggers_enabled = false
+}`
+
+const testAccTFEWorkspace_basicSpeculativeOff = `
+resource "tfe_organization" "foobar" {
+  name  = "tst-terraform"
+  email = "admin@company.com"
+}
+
+resource "tfe_workspace" "foobar" {
+  name                  = "workspace-test"
+  organization          = "${tfe_organization.foobar.id}"
+  auto_apply            = true
+  speculative_enabled = false
 }`
 
 const testAccTFEWorkspace_monorepo = `

--- a/vendor/github.com/hashicorp/go-tfe/README.md
+++ b/vendor/github.com/hashicorp/go-tfe/README.md
@@ -88,7 +88,7 @@ if err != nil {
 	log.Fatal(err)
 }
 
-orgs, err := client.Organizations.List(context.Background(), OrganizationListOptions{})
+orgs, err := client.Organizations.List(context.Background(), tfe.OrganizationListOptions{})
 if err != nil {
 	log.Fatal(err)
 }

--- a/vendor/github.com/hashicorp/go-tfe/tfe.go
+++ b/vendor/github.com/hashicorp/go-tfe/tfe.go
@@ -440,11 +440,9 @@ func (c *Client) newRequest(method, path string, v interface{}) (*retryablehttp.
 		reqHeaders.Set("Content-Type", "application/vnd.api+json")
 
 		if v != nil {
-			buf := bytes.NewBuffer(nil)
-			if err := jsonapi.MarshalPayloadWithoutIncluded(buf, v); err != nil {
+			if body, err = serializeRequestBody(v); err != nil {
 				return nil, err
 			}
-			body = buf
 		}
 	case "PUT":
 		reqHeaders.Set("Accept", "application/json")
@@ -468,6 +466,65 @@ func (c *Client) newRequest(method, path string, v interface{}) (*retryablehttp.
 	}
 
 	return req, nil
+}
+
+// Helper method that serializes the given ptr or ptr slice into a JSON
+// request. It automatically uses jsonapi or json serialization, depending
+// on the body type's tags.
+func serializeRequestBody(v interface{}) (interface{}, error) {
+	// The body can be a slice of pointers or a pointer. In either
+	// case we want to choose the serialization type based on the
+	// individual record type. To determine that type, we need
+	// to either follow the pointer or examine the slice element type.
+	// There are other theoretical possiblities (e. g. maps,
+	// non-pointers) but they wouldn't work anyway because the
+	// json-api library doesn't support serializing other things.
+	var modelType reflect.Type
+	bodyType := reflect.TypeOf(v)
+	invalidBodyError := errors.New("go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice")
+	switch bodyType.Kind() {
+	case reflect.Slice:
+		sliceElem := bodyType.Elem()
+		if sliceElem.Kind() != reflect.Ptr {
+			return nil, invalidBodyError
+		}
+		modelType = sliceElem.Elem()
+	case reflect.Ptr:
+		modelType = reflect.ValueOf(v).Elem().Type()
+	default:
+		return nil, invalidBodyError
+	}
+
+	// Infer whether the request uses jsonapi or regular json
+	// serialization based on how the fields are tagged.
+	jsonApiFields := 0
+	jsonFields := 0
+	for i := 0; i < modelType.NumField(); i++ {
+		structField := modelType.Field(i)
+		if structField.Tag.Get("jsonapi") != "" {
+			jsonApiFields++
+		}
+		if structField.Tag.Get("json") != "" {
+			jsonFields++
+		}
+	}
+	if jsonApiFields > 0 && jsonFields > 0 {
+		// Defining a struct with both json and jsonapi tags doesn't
+		// make sense, because a struct can only be serialized
+		// as one or another. If this does happen, it's a bug
+		// in the library that should be fixed at development time
+		return nil, errors.New("go-tfe bug: struct can't use both json and jsonapi attributes")
+	}
+
+	if jsonFields > 0 {
+		return json.Marshal(v)
+	} else {
+		buf := bytes.NewBuffer(nil)
+		if err := jsonapi.MarshalPayloadWithoutIncluded(buf, v); err != nil {
+			return nil, err
+		}
+		return buf, nil
+	}
 }
 
 // do sends an API request and returns the API response. The API response

--- a/vendor/github.com/hashicorp/go-tfe/workspace.go
+++ b/vendor/github.com/hashicorp/go-tfe/workspace.go
@@ -88,6 +88,7 @@ type Workspace struct {
 	Operations           bool                  `jsonapi:"attr,operations"`
 	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
 	QueueAllRuns         bool                  `jsonapi:"attr,queue-all-runs"`
+	SpeculativeEnabled   bool                  `jsonapi:"attr,speculative-enabled"`
 	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes      []string              `jsonapi:"attr,trigger-prefixes"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`
@@ -186,6 +187,12 @@ type WorkspaceCreateOptions struct {
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
+
+	// Whether this workspace allows speculative plans. Setting this to false
+	// prevents Terraform Cloud or the Terraform Enterprise instance from
+	// running plans on pull requests, which can improve security if the VCS
+	// repository is public or includes untrusted contributors.
+	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace. Upon creating a
 	// workspace, the latest version is selected unless otherwise specified.
@@ -327,6 +334,12 @@ type WorkspaceUpdateOptions struct {
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
+
+	// Whether this workspace allows speculative plans. Setting this to false
+	// prevents Terraform Cloud or the Terraform Enterprise instance from
+	// running plans on pull requests, which can improve security if the VCS
+	// repository is public or includes untrusted contributors.
+	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace.
 	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,7 +99,7 @@ github.com/hashicorp/go-retryablehttp
 github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-slug v0.4.1
 github.com/hashicorp/go-slug
-# github.com/hashicorp/go-tfe v0.10.0
+# github.com/hashicorp/go-tfe v0.10.2
 github.com/hashicorp/go-tfe
 # github.com/hashicorp/go-uuid v1.0.1
 github.com/hashicorp/go-uuid

--- a/website/docs/d/workspace.html.markdown
+++ b/website/docs/d/workspace.html.markdown
@@ -36,6 +36,7 @@ In addition to all arguments above, the following attributes are exported:
 * `file_triggers_enabled` - Indicates whether runs are triggered based on the changed files in a VCS push (if `true`) or always triggered on every push (if `false`).
 * `operations` - Indicates whether the workspace is using remote execution mode. Set to `false` to switch execution mode to local. `true` by default.
 * `queue_all_runs` - Indicates whether all runs should be queued.
+* `speculative_enabled` - Indicates whether this workspace allows speculative plans.
 * `ssh_key_id` - The ID of an SSH key assigned to the workspace.
 * `terraform_version` - The version of Terraform used for this workspace.
 * `trigger_prefixes` - List of repository-root-relative paths which describe all locations to be tracked for changes.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -36,6 +36,10 @@ The following arguments are supported:
 * `queue_all_runs` - (Optional) Whether all runs should be queued. When set
   to `false`, runs triggered by a VCS change will not be queued until at least
   one run is manually queued. Defaults to `true`.
+* `speculative_enabled` - (Optional) Whether this workspace allows speculative
+  plans. Setting this to false prevents Terraform Cloud from running plans on
+  pull requests, which can improve security if the VCS repository is public or
+  includes untrusted contributors. Defaults to `true`.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
 * `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to the latest available version.
 * `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations to be tracked for changes.

--- a/website/docs/r/workspace.html.markdown
+++ b/website/docs/r/workspace.html.markdown
@@ -37,9 +37,10 @@ The following arguments are supported:
   to `false`, runs triggered by a VCS change will not be queued until at least
   one run is manually queued. Defaults to `true`.
 * `speculative_enabled` - (Optional) Whether this workspace allows speculative
-  plans. Setting this to false prevents Terraform Cloud from running plans on
-  pull requests, which can improve security if the VCS repository is public or
-  includes untrusted contributors. Defaults to `true`.
+  plans. Setting this to `false` prevents Terraform Cloud or the Terraform
+  Enterprise instance from running plans on pull requests, which can improve
+  security if the VCS repository is public or includes untrusted contributors.
+  Defaults to `true`.
 * `ssh_key_id` - (Optional) The ID of an SSH key to assign to the workspace.
 * `terraform_version` - (Optional) The version of Terraform to use for this workspace. Defaults to the latest available version.
 * `trigger_prefixes` - (Optional) List of repository-root-relative paths which describe all locations to be tracked for changes.


### PR DESCRIPTION
## Description

* [x] **Requires a go-tfe release with hashicorp/go-tfe#132** -> go-tfe v0.10.2 has been released

This change adds support for the `speculative_enabled` argument to `tfe_workspace`.

Fixes #211

## Testing plan

The tests have been updated to test this in the same way that `file_triggers_enabled` is tested.
`file_triggers_enabled` also defaults to `true` during workspace creation and is thus quite comparable.

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/workspaces.html)

## Output from acceptance tests

```
$ TESTARGS="-run TestAccTFEWorkspace" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEWorkspace -timeout 15m
?   	github.com/terraform-providers/terraform-provider-tfe	[no test files]
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (10.96s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (10.31s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (8.54s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (6.75s)
=== RUN   TestAccTFEWorkspace_panic
--- PASS: TestAccTFEWorkspace_panic (7.31s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (7.28s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (9.51s)
=== RUN   TestAccTFEWorkspace_update
--- PASS: TestAccTFEWorkspace_update (10.76s)
=== RUN   TestAccTFEWorkspace_updateWorkingDirectory
--- PASS: TestAccTFEWorkspace_updateWorkingDirectory (15.61s)
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (11.14s)
=== RUN   TestAccTFEWorkspace_updateTriggerPrefixes
--- PASS: TestAccTFEWorkspace_updateTriggerPrefixes (11.02s)
=== RUN   TestAccTFEWorkspace_updateSpeculative
--- PASS: TestAccTFEWorkspace_updateSpeculative (11.02s)
=== RUN   TestAccTFEWorkspace_updateVCSRepo
    TestAccTFEWorkspace_updateVCSRepo: resource_tfe_workspace_test.go:372: Please set GITHUB_TOKEN to run this test
--- SKIP: TestAccTFEWorkspace_updateVCSRepo (0.54s)
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (16.25s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (7.26s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tfe/tfe	144.541s
?   	github.com/terraform-providers/terraform-provider-tfe/version	[no test files]
```