### PR TITLE
New datasource: tfe_oauth_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.22.0 (Unreleased)
+* **New Data Source:** d/tfe_oauth_client ([#212](https://github.com/terraform-providers/terraform-provider-tfe/pull/212))
 ## 0.21.0 (August 19, 2020)
 
 ENHANCEMENTS:

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -1,0 +1,58 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-tfe"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceTFEOAuthClient() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceTFEOAuthClientRead,
+		Schema: map[string]*schema.Schema{
+			"oauth_client_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ssh_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"token_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"api_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"http_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) error {
+	ctx := context.TODO()
+	tfeClient := meta.(*tfe.Client)
+
+	ocID := d.Get("oauth_client_id").(string)
+
+	oc, err := tfeClient.OAuthClients.Read(ctx, ocID)
+	if err != nil {
+		return fmt.Errorf("Error retrieving OAuth client: %v", err)
+	}
+
+	tokenID := oc.OAuthTokens[0].ID
+	d.SetId(oc.ID)
+	_ = d.Set("ssh_key", oc.RSAPublicKey)
+	_ = d.Set("token_id", tokenID)
+	_ = d.Set("api_url", oc.APIURL)
+	_ = d.Set("http_url", oc.HTTPURL)
+
+	return nil
+}

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -20,10 +20,6 @@ func dataSourceTFEOAuthClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"http_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"oauth_token_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -47,12 +43,19 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error retrieving OAuth client: %v", err)
 	}
 
-	tokenID := oc.OAuthTokens[0].ID
 	d.SetId(oc.ID)
 	_ = d.Set("ssh_key", oc.RSAPublicKey)
-	_ = d.Set("oauth_token_id", tokenID)
 	_ = d.Set("api_url", oc.APIURL)
 	_ = d.Set("http_url", oc.HTTPURL)
+
+	switch len(oc.OAuthTokens) {
+	case 0:
+		d.Set("oauth_token_id", "")
+	case 1:
+		d.Set("oauth_token_id", oc.OAuthTokens[0].ID)
+	default:
+		return fmt.Errorf("Unexpected number of OAuth tokens: %d", len(oc.OAuthTokens))
+	}
 
 	return nil
 }

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -50,7 +50,7 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 	tokenID := oc.OAuthTokens[0].ID
 	d.SetId(oc.ID)
 	_ = d.Set("ssh_key", oc.RSAPublicKey)
-	_ = d.Set("token_id", tokenID)
+	_ = d.Set("oauth_token_id", tokenID)
 	_ = d.Set("api_url", oc.APIURL)
 	_ = d.Set("http_url", oc.HTTPURL)
 

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -20,6 +20,10 @@ func dataSourceTFEOAuthClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"http_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"oauth_token_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -16,19 +16,19 @@ func dataSourceTFEOAuthClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"ssh_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"token_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"api_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"http_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"oauth_token_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ssh_key": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/tfe/data_source_oauth_client.go
+++ b/tfe/data_source_oauth_client.go
@@ -28,10 +28,6 @@ func dataSourceTFEOAuthClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ssh_key": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -48,7 +44,6 @@ func dataSourceTFEOAuthClientRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.SetId(oc.ID)
-	_ = d.Set("ssh_key", oc.RSAPublicKey)
 	_ = d.Set("api_url", oc.APIURL)
 	_ = d.Set("http_url", oc.HTTPURL)
 

--- a/tfe/data_source_oauth_client_test.go
+++ b/tfe/data_source_oauth_client_test.go
@@ -23,7 +23,7 @@ func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
 						"data.tfe_oauth_client.client", "http_url"),
 					resource.TestCheckResourceAttrPair(
 						"tfe_oauth_client.test", "oauth_token_id",
-						"data.tfe_oauth_client.client", "token_id"),
+						"data.tfe_oauth_client.client", "oauth_token_id"),
 				),
 			},
 		},

--- a/tfe/data_source_oauth_client_test.go
+++ b/tfe/data_source_oauth_client_test.go
@@ -1,0 +1,52 @@
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccTFEOAuthClientDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTFEOAuthClientDataSourceConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"tfe_oauth_client.test", "api_url",
+						"data.tfe_oauth_client.client", "api_url"),
+					resource.TestCheckResourceAttrPair(
+						"tfe_oauth_client.test", "http_url",
+						"data.tfe_oauth_client.client", "http_url"),
+					resource.TestCheckResourceAttrPair(
+						"tfe_oauth_client.test", "oauth_token_id",
+						"data.tfe_oauth_client.client", "token_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTFEOAuthClientDataSourceConfig() string {
+	return fmt.Sprintf(`
+	resource "tfe_organization" "foobar" {
+		name  = "tst-terraform"
+		email = "admin@company.com"
+	  }
+	  
+	  resource "tfe_oauth_client" "test" {
+		organization     = "${tfe_organization.foobar.id}"
+		api_url          = "https://api.github.com"
+		http_url         = "https://github.com"
+		oauth_token      = "%s"
+		service_provider = "github"
+	  }	
+
+	  data "tfe_oauth_client" "client" {
+		  oauth_client_id = "${tfe_oauth_client.test.id}"
+	  }
+	`, GITHUB_TOKEN)
+}

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -62,13 +62,13 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 			"tfe_organization_membership": dataSourceTFEOrganizationMembership(),
 			"tfe_ssh_key":                 dataSourceTFESSHKey(),
 			"tfe_team":                    dataSourceTFETeam(),
 			"tfe_team_access":             dataSourceTFETeamAccess(),
 			"tfe_workspace":               dataSourceTFEWorkspace(),
 			"tfe_workspace_ids":           dataSourceTFEWorkspaceIDs(),
-			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/tfe/provider.go
+++ b/tfe/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"tfe_team_access":             dataSourceTFETeamAccess(),
 			"tfe_workspace":               dataSourceTFEWorkspace(),
 			"tfe_workspace_ids":           dataSourceTFEWorkspaceIDs(),
+			"tfe_oauth_client":            dataSourceTFEOAuthClient(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/oauth_client.html.markdown
+++ b/website/docs/d/oauth_client.html.markdown
@@ -28,8 +28,8 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The OAuth client ID.
+* `id` - The OAuth client ID. This will match `oauth_client_id`.
+* `api_url` - The client's API URL.
+* `http_url` - The client's HTTP URL.
+* `oauth_token_id` - The ID of the OAuth token associated with the OAuth client.
 * `ssh_key` - The SSH key assigned to the OAuth client.
-* `token_id` - The ID of the OAuth token associated with te OAuth client.
-* `api_url` - The client's API URL. 
-* `api_url` - The client's HTTP URL.

--- a/website/docs/d/oauth_client.html.markdown
+++ b/website/docs/d/oauth_client.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "tfe"
+page_title: "Terraform Enterprise: tfe_oauth_client"
+sidebar_current: "docs-datasource-tfe-oauth-client-x"
+description: |-
+  Get information on an OAuth client.
+---
+
+# Data Source: tfe_oauth_client
+
+Use this data source to get information about an OAuth client.
+
+## Example Usage
+
+```hcl
+data "tfe_oauth_client" "client" {
+  oauth_client_id = "oc-XXXXXXX"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `oauth_client_id` - (Required) ID of the OAuth client.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The OAuth client ID.
+* `ssh_key` - The SSH key assigned to the OAuth client.
+* `token_id` - The ID of the OAuth token associated with te OAuth client.
+* `api_url` - The client's API URL. 
+* `api_url` - The client's HTTP URL.

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -36,6 +36,9 @@
                         <li<%= sidebar_current("docs-datasource-tfe-workspace-ids") %>>
                             <a href="/docs/providers/tfe/d/workspace_ids.html">tfe_workspace_ids</a>
                         </li>
+                        <li<%= sidebar_current("docs-datasource-tfe-oauth-client") %>>
+                            <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
+                        </li>
                     </ul>
                 </li>
 

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -13,7 +13,7 @@
                 <li<%= sidebar_current("docs-tfe-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
-                        <li<%= sidebar_current("docs-datasource-tfe-oauth-client") %>>
+                        <li<%= sidebar_current("docs-datasource-tfe-oauth-client-x") %>>
                             <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
                         </li>
                         <li<%= sidebar_current("docs-datasource-tfe-organization-membership") %>>

--- a/website/tfe.erb
+++ b/website/tfe.erb
@@ -13,6 +13,9 @@
                 <li<%= sidebar_current("docs-tfe-datasource") %>>
                     <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-datasource-tfe-oauth-client") %>>
+                            <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
+                        </li>
                         <li<%= sidebar_current("docs-datasource-tfe-organization-membership") %>>
                             <a href="/docs/providers/tfe/d/organization_membership.html">tfe_organization_membership</a>
                         </li>
@@ -35,9 +38,6 @@
 
                         <li<%= sidebar_current("docs-datasource-tfe-workspace-ids") %>>
                             <a href="/docs/providers/tfe/d/workspace_ids.html">tfe_workspace_ids</a>
-                        </li>
-                        <li<%= sidebar_current("docs-datasource-tfe-oauth-client") %>>
-                            <a href="/docs/providers/tfe/d/oauth_client.html">tfe_oauth_client</a>
                         </li>
                     </ul>
                 </li>


### PR DESCRIPTION
## Description

This is a new datasource that allows users to extract information from
existing oauth clients.

## Output from acceptance tests

```
❯ TESTARGS='-run TestAccTFEOAuthClientDataSource_basic' make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccTFEOAuthClientDataSource_basic -timeout 15m
?       github.com/terraform-providers/terraform-provider-tfe   [no test files]
=== RUN   TestAccTFEOAuthClientDataSource_basic
--- PASS: TestAccTFEOAuthClientDataSource_basic (29.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-tfe/tfe       30.846s
?       github.com/terraform-providers/terraform-provider-tfe/version   [no test files]
```