### PR TITLE
Fixed not being able to get VCS branch name when importing workspace

### DIFF
--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -163,6 +163,7 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 
 		options.VCSRepo = &tfe.VCSRepoOptions{
 			Identifier:        tfe.String(vcsRepo["identifier"].(string)),
+			Branch:            tfe.String(vcsRepo["branch"].(string)),
 			IngressSubmodules: tfe.Bool(vcsRepo["ingress_submodules"].(bool)),
 			OAuthTokenID:      tfe.String(vcsRepo["oauth_token_id"].(string)),
 		}
@@ -231,6 +232,7 @@ func resourceTFEWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
 	if workspace.VCSRepo != nil {
 		vcsConfig := map[string]interface{}{
 			"identifier":         workspace.VCSRepo.Identifier,
+			"branch":             workspace.VCSRepo.Branch,
 			"ingress_submodules": workspace.VCSRepo.IngressSubmodules,
 			"oauth_token_id":     workspace.VCSRepo.OAuthTokenID,
 		}


### PR DESCRIPTION
## Description

Hello.
This request fixes the one that can't get the branch name when importing the workspace.
As I wrote in Issue #216 , I have confirmed the phenomenon by the following method.

----
executed API...
```
$ curl \
>   --header "Authorization: Bearer $TOKEN" \
>   --header "Content-Type: application/vnd.api+json" \
>   https://app.terraform.io/api/v2/organizations/kuroseets/workspaces | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2422    0  2422    0     0   3035      0 --:--:-- --:--:-- --:--:--  3031
{
  "data": [
    {
      "id": "WORKSPACE_ID",
      "type": "workspaces",
      "attributes": {
        "name": "terraform-provider-tfe-dev",
        "auto-apply": false,
        "created-at": "2020-08-22T02:01:02.485Z",
        "environment": "default",
        "locked": false,
        "queue-all-runs": false,
        "terraform-version": "0.13.0",
        "working-directory": "",
        "speculative-enabled": true,
        "allow-destroy-plan": true,
        "auto-destroy-at": null,
        "latest-change-at": "2020-08-22T02:01:02.485Z",
        "operations": true,
        "execution-mode": "remote",
        "vcs-repo": {
          "branch": "tfe_workspace-vcs_repo-branch",
          "ingress-submodules": false,
          "identifier": "kuroseets/terraform-provider-tfe",
          "display-identifier": "kuroseets/terraform-provider-tfe",
...
```
on terraform
```
$ cat << EOF > main.tf
provider "tfe" {
  token    = "TERRAFORM_CLOUD TOKEN"
}

resource "tfe_workspace" "test" {

}
EOF
$ terraform init

Initializing the backend...
...
* provider.tfe: version = "~> 0.21"

Terraform has been successfully initialized!
...
$ terraform import tfe_workspace.test ws-WORKSPACE_ID
tfe_workspace.test: Importing from ID "ws-WORKSPACE_ID"...
tfe_workspace.test: Import prepared!
  Prepared tfe_workspace for import
tfe_workspace.test: Refreshing state... [id=ws-WORKSPACE_ID]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
$ cat terraform.tfstate
...
      "instances": [
        {
          "schema_version": 1,
          "attributes": {
            "auto_apply": false,
            "external_id": "ws-WORKSPACE_ID",
            "file_triggers_enabled": false,
            "id": "ws-WORKSPACE_ID",
            "name": "terraform-provider-tfe-dev",
            "operations": true,
            "organization": "kuroseets",
            "queue_all_runs": false,
            "ssh_key_id": "",
            "terraform_version": "0.13.0",
            "trigger_prefixes": [],
            "vcs_repo": [
              {
                "branch": "",
                "identifier": "kuroseets/terraform-provider-tfe",
                "ingress_submodules": false,
...
```
## Testing plan

I replaced it with a modified provider and ran it and took the diff.

```
$ cd .terraform/plugins/registry.terraform.io/hashicorp/tfe/0.21.0/darwin_amd64
$ mv terraform-provider-tfe_v0.21.0_x4 terraform-provider-tfe_v0.21.0_x4.org
$ mv DEVELOPMENT_PROVIDER terraform-provider-tfe_v0.21.0_x4
$ cd -
$ mv terraform.tfstate terraform.tfstate.bak
$ terraform init
$ terraform import tfe_workspace.test ws-WORKSPACE_ID
$ diff -u terraform.tfstate.bak terraform.tfstate
@@ -27,7 +27,7 @@
             "trigger_prefixes": [],
             "vcs_repo": [
               {
-                "branch": "",
+                "branch": "tfe_workspace-vcs_repo-branch",
                 "identifier": "kuroseets/terraform-provider-tfe",
                 "ingress_submodules": false,
                 "oauth_token_id": "ot-XXXXXXXXXXXXX"
```

## External links

- https://github.com/terraform-providers/terraform-provider-tfe/issues/216

## Output from acceptance tests

```
$ make testacc TESTARGS='-run TestAccTFEWorkspace'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./tfe -v -run TestAccTFEWorkspace -timeout 15m
=== RUN   TestAccTFEWorkspaceIDsDataSource_basic
--- PASS: TestAccTFEWorkspaceIDsDataSource_basic (13.29s)
=== RUN   TestAccTFEWorkspaceIDsDataSource_wildcard
--- PASS: TestAccTFEWorkspaceIDsDataSource_wildcard (12.57s)
=== RUN   TestAccTFEWorkspaceDataSource_basic
--- PASS: TestAccTFEWorkspaceDataSource_basic (11.88s)
=== RUN   TestAccTFEWorkspace_basic
--- PASS: TestAccTFEWorkspace_basic (9.62s)
=== RUN   TestAccTFEWorkspace_panic
--- PASS: TestAccTFEWorkspace_panic (9.56s)
=== RUN   TestAccTFEWorkspace_monorepo
--- PASS: TestAccTFEWorkspace_monorepo (10.01s)
=== RUN   TestAccTFEWorkspace_renamed
--- PASS: TestAccTFEWorkspace_renamed (14.53s)
=== RUN   TestAccTFEWorkspace_update
--- PASS: TestAccTFEWorkspace_update (22.05s)
=== RUN   TestAccTFEWorkspace_updateWorkingDirectory
--- PASS: TestAccTFEWorkspace_updateWorkingDirectory (28.26s)
=== RUN   TestAccTFEWorkspace_updateFileTriggers
--- PASS: TestAccTFEWorkspace_updateFileTriggers (19.52s)
=== RUN   TestAccTFEWorkspace_updateTriggerPrefixes
--- PASS: TestAccTFEWorkspace_updateTriggerPrefixes (21.95s)
=== RUN   TestAccTFEWorkspace_updateVCSRepo
--- SKIP: TestAccTFEWorkspace_updateVCSRepo (1.41s)
    resource_tfe_workspace_test.go:339: Please set GITHUB_TOKEN to run this test
=== RUN   TestAccTFEWorkspace_sshKey
--- PASS: TestAccTFEWorkspace_sshKey (29.01s)
=== RUN   TestAccTFEWorkspace_import
--- PASS: TestAccTFEWorkspace_import (15.27s)
PASS
ok  	github.com/terraform-providers/terraform-provider-tfe/tfe	219.215s
```
----
Please review and point out
Thank you.