### PR TITLE
[tfe_registry_module] Docs: Remove errant 's' from resource name

### DIFF
--- a/website/docs/r/registry_module.html.markdown
+++ b/website/docs/r/registry_module.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages registry modules
 ---
 
-# tfe_registry_modules
+# tfe_registry_module
 
 Terraform Cloud's private module registry helps you share Terraform modules across your organization. 
 


### PR DESCRIPTION
## Description

The documentation currently has the name of at the top of the page as `tfe_registry_modules`, however, the resource name is `tfe_registry_module`. Removing the errant 's'. 