### PR TITLE
Fix type conversion bug

### DIFF
--- a/tfe/resource_tfe_workspace.go
+++ b/tfe/resource_tfe_workspace.go
@@ -153,7 +153,9 @@ func resourceTFEWorkspaceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if tps, ok := d.GetOk("trigger_prefixes"); ok {
 		for _, tp := range tps.([]interface{}) {
-			options.TriggerPrefixes = append(options.TriggerPrefixes, tp.(string))
+			if t, ok := tp.(string); ok {
+				options.TriggerPrefixes = append(options.TriggerPrefixes, t)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

While iterating over a trigger prefix list sometimes items can be nil.
We are now checking if conversion is possible instead of "blindly"
converting them and potentially causing a crash.

