### PR TITLE
Set variable id to null if workspace id doesnt exist

### DIFF
--- a/tfe/resource_tfe_variable.go
+++ b/tfe/resource_tfe_variable.go
@@ -133,6 +133,11 @@ func resourceTFEVariableRead(d *schema.ResourceData, meta interface{}) error {
 	workspaceID := d.Get("workspace_id").(string)
 	ws, err := tfeClient.Workspaces.ReadByID(ctx, workspaceID)
 	if err != nil {
+		if err == tfe.ErrResourceNotFound {
+			log.Printf("[DEBUG] Workspace %s no longer exists", workspaceID)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf(
 			"Error retrieving workspace %s: %v", workspaceID, err)
 	}


### PR DESCRIPTION
## Description

Addresses https://github.com/terraform-providers/terraform-provider-tfe/issues/195
Configuration containing a TFE variable will fail if the workspace is destroyed in the UI. This change destroys the variable resource in state if the workspace it belongs to no longer exists.

## BREAKING CHANGE

_Delete this section if your change is not introducing a breaking change to the provider or a breaking change from the TFE API_

- [ ] New TFE API version created
- [ ] Provider restricted to TFE API version

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example Terraform configs where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [go-tfe documentation](https://pkg.go.dev/github.com/hashicorp/go-tfe?tab=doc#xxxx)
- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

## Output from acceptance tests

_Please run the full suite of acceptance tests locally and include the output here._

```
$ make testacc

...
```